### PR TITLE
Rename currency fields subunits -> major units

### DIFF
--- a/crates/protocol/src/message/quote.rs
+++ b/crates/protocol/src/message/quote.rs
@@ -56,9 +56,9 @@ pub struct QuoteDetails {
     /// ISO 3166 currency code string
     pub currency_code: String,
     /// The amount of currency expressed in the smallest respective unit
-    pub amount_subunits: String,
+    pub amount: String,
     /// The amount paid in fees expressed in the smallest respectice unit
-    pub fee_subunits: Option<String>,
+    pub fee: Option<String>,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
@@ -98,13 +98,13 @@ mod tests {
                 expires_at: Utc::now(),
                 payin: QuoteDetails {
                     currency_code: "USD".to_string(),
-                    amount_subunits: "100".to_string(),
-                    fee_subunits: Some("10".to_string()),
+                    amount: "1.00".to_string(),
+                    fee: Some("0.10".to_string()),
                 },
                 payout: QuoteDetails {
                     currency_code: "BTC".to_string(),
-                    amount_subunits: "2500".to_string(),
-                    fee_subunits: None,
+                    amount: "25.00".to_string(),
+                    fee: None,
                 },
                 payment_instructions: Some(PaymentInstructions {
                     payin: Some(PaymentInstruction {

--- a/crates/protocol/src/resource/offering.rs
+++ b/crates/protocol/src/resource/offering.rs
@@ -62,9 +62,9 @@ pub struct CurrencyDetails {
     /// ISO 3166 currency code string
     pub currency_code: String,
     /// Minimum amount of currency that the offer is valid for
-    pub min_subunits: Option<String>,
+    pub min_amount: Option<String>,
     /// Maximum amount of currency that the offer is valid for
-    pub max_subunits: Option<String>,
+    pub max_amount: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize, PartialEq, Serialize)]
@@ -77,7 +77,7 @@ pub struct PaymentMethod {
     /// payment method
     pub required_payment_details: Option<JsonValue>,
     /// The fee expressed in the currency's sub units to make use of this payment method
-    pub fee_subunits: Option<String>,
+    pub fee: Option<String>,
 }
 
 impl PaymentMethod {

--- a/crates/protocol/src/test_data.rs
+++ b/crates/protocol/src/test_data.rs
@@ -21,8 +21,8 @@ impl TestData {
                 payout_units_per_payin_unit: "1".to_string(),
                 payin_currency: CurrencyDetails {
                     currency_code: "AUD".to_string(),
-                    min_subunits: Some("1".to_string()),
-                    max_subunits: Some("10000".to_string()),
+                    min_amount: Some("1".to_string()),
+                    max_amount: Some("10000".to_string()),
                 },
                 payout_currency: CurrencyDetails {
                     currency_code: "USDC".to_string(),
@@ -67,13 +67,13 @@ impl TestData {
                 expires_at: Utc::now(),
                 payin: QuoteDetails {
                     currency_code: "USD".to_string(),
-                    amount_subunits: "100".to_string(),
-                    fee_subunits: Some("10".to_string()),
+                    amount: "1.00".to_string(),
+                    fee: Some("10".to_string()),
                 },
                 payout: QuoteDetails {
                     currency_code: "BTC".to_string(),
-                    amount_subunits: "2500".to_string(),
-                    fee_subunits: None,
+                    amount: "2500".to_string(),
+                    fee: None,
                 },
                 payment_instructions: Some(PaymentInstructions {
                     payin: Some(PaymentInstruction {


### PR DESCRIPTION
Update currency amount representation and validation based on this spec change: https://github.com/TBD54566975/tbdex/pull/206

## Changes based on the spec
> 
> Update the protocol spec, test-vectors, and examples to represent currencies as decided in issue #199 in [this comment here](https://github.com/TBD54566975/tbdex/issues/199#issuecomment-1850946932).
> 1. Strings
> 2. Containing major unit amounts
> 3. Decimals using period `.` as the decimal separator regardless of currency.
> https://github.com/TBD54566975/tbdex/issues/199#issuecomment-1850946932
> 
> The updated fields taken from [this comment here](https://github.com/TBD54566975/tbdex/issues/199#issuecomment-1846472273).
> | Old                                  | New                       |
> | ---------------------------------------- | ------------------------- |
> | `offering.payinCurrency.minSubunits`     | `min` or `minAmount`      |
> | `offering.payinCurrency.maxSubunits`     | `max` or `maxAmount`      |
> | `offering.payoutCurrency.minSubunits`    | `min` or `minAmount`      |
> | `offering.payoutCurrency.maxSubunits`    | `max` or `maxAmount`      |
> | `offering.paymentMethods[*].feeSubunits` | `fee`                     |
> | `rfq.payinSubunits`                      | `amount` or `payinAmount` |
> | `quote.payin.amountSubunits`             | `amount`                  |
> | `quote.payin.feeSubunits`                | `fee`                     |
> | `quote.payout.amountSubunits`            | `amount`                  |
> | `quote.payout.feeSubunits`               | `fee`                     |

## Notes
This PR does NOT validate that currency amount strings are decimals. That will come in a later PR which validates TBDex messages/resources against the published JSON schema. [tbdex-js already does this](https://github.com/TBD54566975/tbdex-js/blob/main/packages/protocol/build/compile-validators.js#L20-L31).