### PR TITLE
Bring resource and offering data structures up to latest spec

### DIFF
--- a/crates/protocol/src/resources/mod.rs
+++ b/crates/protocol/src/resources/mod.rs
@@ -25,7 +25,9 @@ pub struct ResourceMetadata {
     /// ISO 8601 timestamp
     pub created_at: DateTime<Utc>,
     /// ISO 8601 timestamp
-    pub updated_at: DateTime<Utc>,
+    pub updated_at: Option<DateTime<Utc>>,
+    /// Version of the protocol in use (x.x format). The protocol version must remain consistent across messages in a given exchange. Messages sharing the same exchangeId MUST also have the same protocol version.
+    pub protocol: String,
 }
 
 /// A struct representing the structure and common functionality available to all Resources.
@@ -37,7 +39,7 @@ pub struct Resource<T> {
     /// The actual Resource content
     pub data: T,
     /// The signature that verifies the authenticity and integrity of the Resource
-    pub signature: Option<String>,
+    pub signature: String,
 }
 
 /// Errors that can occur when working with [`Resource`]s.

--- a/crates/protocol/src/test_data.rs
+++ b/crates/protocol/src/test_data.rs
@@ -3,7 +3,9 @@ use crate::messages::quote::{
     PaymentInstruction, PaymentInstructions, Quote, QuoteData, QuoteDetails,
 };
 use crate::messages::Message;
-use crate::resources::offering::{CurrencyDetails, Offering, OfferingData, PaymentMethod};
+use crate::resources::offering::{
+    CreateOptions, Offering, OfferingData, PayinDetails, PayoutDetails,
+};
 use crate::resources::Resource;
 use chrono::Utc;
 use credentials::pex::v2::{Constraints, Field, InputDescriptor, PresentationDefinition};
@@ -16,33 +18,23 @@ pub struct TestData;
 #[cfg(test)]
 impl TestData {
     pub fn get_offering(from: String) -> Resource<OfferingData> {
-        Offering::create(
+        Offering::create(CreateOptions {
             from,
-            OfferingData {
-                description: "A sample offering".to_string(),
-                payout_units_per_payin_unit: "1".to_string(),
-                payin_currency: CurrencyDetails {
-                    currency_code: "AUD".to_string(),
-                    min_subunits: Some("1".to_string()),
-                    max_subunits: Some("10000".to_string()),
-                },
-                payout_currency: CurrencyDetails {
-                    currency_code: "USDC".to_string(),
+            data: OfferingData {
+                description: "my fake offering".to_string(),
+                payout_units_per_payin_unit: "2".to_string(),
+                payin: PayinDetails {
+                    currency_code: "USD".to_string(),
                     ..Default::default()
                 },
-                payin_methods: vec![PaymentMethod {
-                    kind: "BTC_ADDRESS".to_string(),
-                    required_payment_details: Some(TestData::required_payment_details_schema()),
+                payout: PayoutDetails {
+                    currency_code: "BTC".to_string(),
                     ..Default::default()
-                }],
-                payout_methods: vec![PaymentMethod {
-                    kind: "MOMO".to_string(),
-                    required_payment_details: Some(TestData::required_payment_details_schema()),
-                    ..Default::default()
-                }],
+                },
                 required_claims: TestData::get_presentation_definition(),
             },
-        )
+            ..Default::default()
+        })
         .expect("failed to create offering")
     }
 


### PR DESCRIPTION
Closes https://github.com/TBD54566975/tbdex-rs/issues/55

Some implications in these changes which will span to subsequent changes (please object if you take issue):

- signatures shouldn't be optional (`Option<T>` type) because that isn't how they exist in the spec. this implies that during the `create()` we will create the signatures (that is TODO, added comment linking to relevant ticket).
- we're going to follow a `create(options: CreateOptions)` paradigm as opposed to inlining all the parameters
- removed a function `required_payment_details_schema` which may become relevant again once we address #54 but for now it's not relevant

Created tickets for subsequent work during this work:
- https://github.com/TBD54566975/tbdex-rs/issues/53
- https://github.com/TBD54566975/tbdex-rs/issues/54
- https://github.com/TBD54566975/tbdex-rs/issues/52