### PR TITLE
Auto print error type, variant and message for RustCoreError

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ license-file = "LICENSE"
 serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
 thiserror = "1.0.50"
-web5 = { git = "https://github.com/TBD54566975/web5-rs", rev = "9a212f037d51233edc90c177df7355728d0f5886" }
+web5 = { git = "https://github.com/TBD54566975/web5-rs", rev = "a73efd745036861a03bdf33984af6ae10536e6f4" }

--- a/bindings/tbdex_uniffi/Cargo.toml
+++ b/bindings/tbdex_uniffi/Cargo.toml
@@ -12,7 +12,7 @@ tbdex = { path = "../../crates/tbdex" }
 thiserror = { workspace = true }
 uniffi = { version = "0.27.1", features = ["cli"] }
 web5 = { workspace = true }
-web5_uniffi_wrapper = { git = "https://github.com/TBD54566975/web5-rs", rev = "9a212f037d51233edc90c177df7355728d0f5886" }
+web5_uniffi_wrapper = { git = "https://github.com/TBD54566975/web5-rs", rev = "a73efd745036861a03bdf33984af6ae10536e6f4" }
 
 [build-dependencies]
 uniffi = { version = "0.27.1", features = ["build"] }

--- a/bindings/tbdex_uniffi/src/errors.rs
+++ b/bindings/tbdex_uniffi/src/errors.rs
@@ -1,5 +1,5 @@
 use serde_json::Error as SerdeJsonError;
-use std::sync::{Arc, PoisonError};
+use std::sync::PoisonError;
 use std::{any::type_name, fmt::Debug};
 use tbdex::http_client::HttpClientError;
 use tbdex::messages::MessageError;
@@ -8,21 +8,21 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum RustCoreError {
-    #[error("{message}")]
+    #[error("{msg}")]
     Error {
         r#type: String,
         variant: String,
-        message: String,
+        msg: String,
     },
 }
 
 impl RustCoreError {
-    pub fn from_poison_error<T>(error: PoisonError<T>, error_type: &str) -> Arc<Self> {
-        Arc::new(RustCoreError::Error {
+    pub fn from_poison_error<T>(error: PoisonError<T>, error_type: &str) -> Self {
+        RustCoreError::Error {
             r#type: error_type.to_string(),
             variant: "PoisonError".to_string(),
-            message: error.to_string(),
-        })
+            msg: error.to_string(),
+        }
     }
     fn new<T>(error: T) -> Self
     where
@@ -31,30 +31,7 @@ impl RustCoreError {
         Self::Error {
             r#type: type_of(&error).to_string(),
             variant: variant_name(&error),
-            message: error.to_string(),
-        }
-    }
-
-    pub fn error_type(&self) -> String {
-        match self {
-            RustCoreError::Error {
-                r#type: error_type, ..
-            } => error_type.clone(),
-        }
-    }
-
-    pub fn variant(&self) -> String {
-        match self {
-            RustCoreError::Error {
-                variant: error_variant,
-                ..
-            } => error_variant.clone(),
-        }
-    }
-
-    pub fn message(&self) -> String {
-        match self {
-            RustCoreError::Error { message, .. } => message.clone(),
+            msg: error.to_string(),
         }
     }
 }
@@ -96,4 +73,4 @@ impl From<SerdeJsonError> for RustCoreError {
     }
 }
 
-pub type Result<T> = std::result::Result<T, Arc<RustCoreError>>;
+pub type Result<T> = std::result::Result<T, RustCoreError>;

--- a/bindings/tbdex_uniffi/src/http_client/balances.rs
+++ b/bindings/tbdex_uniffi/src/http_client/balances.rs
@@ -4,8 +4,7 @@ use web5_uniffi_wrapper::dids::bearer_did::BearerDid;
 
 pub fn get_balances(pfi_did_uri: String, bearer_did: Arc<BearerDid>) -> Result<Vec<Arc<Balance>>> {
     let inner_balances =
-        tbdex::http_client::balances::get_balances(&pfi_did_uri, &bearer_did.0.clone())
-            .map_err(|e| Arc::new(e.into()))?;
+        tbdex::http_client::balances::get_balances(&pfi_did_uri, &bearer_did.0.clone())?;
 
     let balances = inner_balances
         .into_iter()

--- a/bindings/tbdex_uniffi/src/http_client/exchanges.rs
+++ b/bindings/tbdex_uniffi/src/http_client/exchanges.rs
@@ -40,20 +40,17 @@ impl Exchange {
 }
 
 pub fn create_exchange(rfq: Arc<Rfq>, reply_to: Option<String>) -> Result<()> {
-    tbdex::http_client::exchanges::create_exchange(&rfq.to_inner()?, reply_to)
-        .map_err(|e| Arc::new(e.into()))?;
+    tbdex::http_client::exchanges::create_exchange(&rfq.to_inner()?, reply_to)?;
     Ok(())
 }
 
 pub fn submit_order(order: Arc<Order>) -> Result<()> {
-    tbdex::http_client::exchanges::submit_order(&order.get_data()?)
-        .map_err(|e| Arc::new(e.into()))?;
+    tbdex::http_client::exchanges::submit_order(&order.get_data()?)?;
     Ok(())
 }
 
 pub fn submit_close(close: Arc<Close>) -> Result<()> {
-    tbdex::http_client::exchanges::submit_close(&close.get_data()?)
-        .map_err(|e| Arc::new(e.into()))?;
+    tbdex::http_client::exchanges::submit_close(&close.get_data()?)?;
     Ok(())
 }
 
@@ -66,15 +63,13 @@ pub fn get_exchange(
         &pfi_did_uri,
         &bearer_did.0.clone(),
         &exchange_id,
-    )
-    .map_err(|e| Arc::new(e.into()))?;
+    )?;
 
     Ok(Exchange::from_inner(inner_exchange))
 }
 
 pub fn get_exchanges(pfi_did_uri: String, bearer_did: Arc<BearerDid>) -> Result<Vec<String>> {
     let exchange_ids =
-        tbdex::http_client::exchanges::get_exchanges(&pfi_did_uri, &bearer_did.0.clone())
-            .map_err(|e| Arc::new(e.into()))?;
+        tbdex::http_client::exchanges::get_exchanges(&pfi_did_uri, &bearer_did.0.clone())?;
     Ok(exchange_ids)
 }

--- a/bindings/tbdex_uniffi/src/http_client/offerings.rs
+++ b/bindings/tbdex_uniffi/src/http_client/offerings.rs
@@ -2,8 +2,7 @@ use crate::{errors::Result, resources::offering::Offering};
 use std::sync::{Arc, RwLock};
 
 pub fn get_offerings(pfi_did_uri: String) -> Result<Vec<Arc<Offering>>> {
-    let inner_offerings = tbdex::http_client::offerings::get_offerings(&pfi_did_uri)
-        .map_err(|e| Arc::new(e.into()))?;
+    let inner_offerings = tbdex::http_client::offerings::get_offerings(&pfi_did_uri)?;
 
     let offerings = inner_offerings
         .into_iter()

--- a/bindings/tbdex_uniffi/src/messages/close.rs
+++ b/bindings/tbdex_uniffi/src/messages/close.rs
@@ -23,13 +23,14 @@ impl Close {
             &data,
             &protocol,
             external_id,
-        )
-        .map_err(|e| Arc::new(e.into()))?;
+        )?;
+
         Ok(Self(Arc::new(RwLock::new(close))))
     }
 
     pub fn from_json_string(json: &str) -> Result<Self> {
-        let inner_close = InnerClose::from_json_string(json).map_err(|e| Arc::new(e.into()))?;
+        let inner_close = InnerClose::from_json_string(json)?;
+
         Ok(Self(Arc::new(RwLock::new(inner_close))))
     }
 
@@ -38,7 +39,8 @@ impl Close {
             .0
             .read()
             .map_err(|e| RustCoreError::from_poison_error(e, "RwLockReadError"))?;
-        inner_close.to_json().map_err(|e| Arc::new(e.into()))
+
+        Ok(inner_close.to_json()?)
     }
 
     pub fn get_data(&self) -> Result<InnerClose> {
@@ -46,6 +48,7 @@ impl Close {
             .0
             .read()
             .map_err(|e| RustCoreError::from_poison_error(e, "RwLockReadError"))?;
+
         Ok(close.clone())
     }
 }

--- a/bindings/tbdex_uniffi/src/messages/order.rs
+++ b/bindings/tbdex_uniffi/src/messages/order.rs
@@ -21,13 +21,14 @@ impl Order {
             &exchange_id,
             &protocol,
             external_id,
-        )
-        .map_err(|e| Arc::new(e.into()))?;
+        )?;
+
         Ok(Self(Arc::new(RwLock::new(order))))
     }
 
     pub fn from_json_string(json: &str) -> Result<Self> {
-        let inner_order = InnerOrder::from_json_string(json).map_err(|e| Arc::new(e.into()))?;
+        let inner_order = InnerOrder::from_json_string(json)?;
+
         Ok(Self(Arc::new(RwLock::new(inner_order))))
     }
 
@@ -36,7 +37,8 @@ impl Order {
             .0
             .read()
             .map_err(|e| RustCoreError::from_poison_error(e, "RwLockReadError"))?;
-        inner_order.to_json().map_err(|e| Arc::new(e.into()))
+
+        Ok(inner_order.to_json()?)
     }
 
     pub fn get_data(&self) -> Result<InnerOrder> {
@@ -44,6 +46,7 @@ impl Order {
             .0
             .read()
             .map_err(|e| RustCoreError::from_poison_error(e, "RwLockReadError"))?;
+
         Ok(order.clone())
     }
 }

--- a/bindings/tbdex_uniffi/src/messages/order_status.rs
+++ b/bindings/tbdex_uniffi/src/messages/order_status.rs
@@ -23,14 +23,14 @@ impl OrderStatus {
             &data,
             &protocol,
             external_id,
-        )
-        .map_err(|e| Arc::new(e.into()))?;
+        )?;
+
         Ok(Self(Arc::new(RwLock::new(order_status))))
     }
 
     pub fn from_json_string(json: &str) -> Result<Self> {
-        let inner_order_status =
-            InnerOrderStatus::from_json_string(json).map_err(|e| Arc::new(e.into()))?;
+        let inner_order_status = InnerOrderStatus::from_json_string(json)?;
+
         Ok(Self(Arc::new(RwLock::new(inner_order_status))))
     }
 
@@ -39,7 +39,8 @@ impl OrderStatus {
             .0
             .read()
             .map_err(|e| RustCoreError::from_poison_error(e, "RwLockReadError"))?;
-        inner_order_status.to_json().map_err(|e| Arc::new(e.into()))
+
+        Ok(inner_order_status.to_json()?)
     }
 
     pub fn get_data(&self) -> Result<InnerOrderStatus> {
@@ -47,6 +48,7 @@ impl OrderStatus {
             .0
             .read()
             .map_err(|e| RustCoreError::from_poison_error(e, "RwLockReadError"))?;
+
         Ok(order_status.clone())
     }
 }

--- a/bindings/tbdex_uniffi/src/messages/quote.rs
+++ b/bindings/tbdex_uniffi/src/messages/quote.rs
@@ -23,13 +23,14 @@ impl Quote {
             &data,
             &protocol,
             external_id,
-        )
-        .map_err(|e| Arc::new(e.into()))?;
+        )?;
+
         Ok(Self(Arc::new(RwLock::new(quote))))
     }
 
     pub fn from_json_string(json: &str) -> Result<Self> {
-        let inner_quote = InnerQuote::from_json_string(json).map_err(|e| Arc::new(e.into()))?;
+        let inner_quote = InnerQuote::from_json_string(json)?;
+
         Ok(Self(Arc::new(RwLock::new(inner_quote))))
     }
 
@@ -38,7 +39,8 @@ impl Quote {
             .0
             .read()
             .map_err(|e| RustCoreError::from_poison_error(e, "RwLockReadError"))?;
-        inner_quote.to_json().map_err(|e| Arc::new(e.into()))
+
+        Ok(inner_quote.to_json()?)
     }
 
     pub fn get_data(&self) -> Result<InnerQuote> {
@@ -46,6 +48,7 @@ impl Quote {
             .0
             .read()
             .map_err(|e| RustCoreError::from_poison_error(e, "RwLockReadError"))?;
+
         Ok(quote.clone())
     }
 }

--- a/bindings/tbdex_uniffi/src/messages/rfq.rs
+++ b/bindings/tbdex_uniffi/src/messages/rfq.rs
@@ -18,8 +18,7 @@ impl Rfq {
         external_id: Option<String>,
     ) -> Result<Self> {
         let create_rfq_data =
-            serde_json::from_str::<InnerCreateRfqData>(&json_serialized_create_rfq_data)
-                .map_err(|e| Arc::new(e.into()))?;
+            serde_json::from_str::<InnerCreateRfqData>(&json_serialized_create_rfq_data)?;
         let rfq = InnerRfq::new(
             &bearer_did.0.clone(),
             &to,
@@ -27,14 +26,14 @@ impl Rfq {
             &create_rfq_data,
             &protocol,
             external_id,
-        )
-        .map_err(|e| Arc::new(e.into()))?;
+        )?;
+
         Ok(Self(Arc::new(RwLock::new(rfq))))
     }
 
     pub fn from_json_string(json: &str, require_all_private_data: bool) -> Result<Self> {
-        let inner_rfq = InnerRfq::from_json_string(json, require_all_private_data)
-            .map_err(|e| Arc::new(e.into()))?;
+        let inner_rfq = InnerRfq::from_json_string(json, require_all_private_data)?;
+
         Ok(Self(Arc::new(RwLock::new(inner_rfq))))
     }
 
@@ -43,7 +42,8 @@ impl Rfq {
             .0
             .read()
             .map_err(|e| RustCoreError::from_poison_error(e, "RwLockReadError"))?;
-        inner_rfq.to_json().map_err(|e| Arc::new(e.into()))
+
+        Ok(inner_rfq.to_json()?)
     }
 
     pub fn get_data(&self) -> Result<data::Rfq> {
@@ -51,10 +51,8 @@ impl Rfq {
             .0
             .read()
             .map_err(|e| RustCoreError::from_poison_error(e, "RwLockReadError"))?;
-        let json_serialized_data =
-            serde_json::to_string(&inner_rfq.data.clone()).map_err(|e| Arc::new(e.into()))?;
-        let json_serialized_private_data = serde_json::to_string(&inner_rfq.private_data.clone())
-            .map_err(|e| Arc::new(e.into()))?;
+        let json_serialized_data = serde_json::to_string(&inner_rfq.data.clone())?;
+        let json_serialized_private_data = serde_json::to_string(&inner_rfq.private_data.clone())?;
         Ok(data::Rfq {
             metadata: inner_rfq.metadata.clone(),
             json_serialized_data,
@@ -68,6 +66,7 @@ impl Rfq {
             .0
             .read()
             .map_err(|e| RustCoreError::from_poison_error(e, "RwLockReadError"))?;
+
         Ok(inner_rfq.clone())
     }
 
@@ -76,8 +75,8 @@ impl Rfq {
             .0
             .read()
             .map_err(|e| RustCoreError::from_poison_error(e, "RwLockReadError"))?;
-        rfq.verify_offering_requirements(&offering.to_inner()?)
-            .map_err(|e| Arc::new(e.into()))
+
+        Ok(rfq.verify_offering_requirements(&offering.to_inner()?)?)
     }
 
     pub fn verify_all_private_data(&self) -> Result<bool> {
@@ -85,8 +84,8 @@ impl Rfq {
             .0
             .read()
             .map_err(|e| RustCoreError::from_poison_error(e, "RwLockReadError"))?;
-        rfq.verify_all_private_data()
-            .map_err(|e| Arc::new(e.into()))
+
+        Ok(rfq.verify_all_private_data()?)
     }
 
     pub fn verify_present_private_data(&self) -> Result<bool> {
@@ -94,8 +93,8 @@ impl Rfq {
             .0
             .read()
             .map_err(|e| RustCoreError::from_poison_error(e, "RwLockReadError"))?;
-        rfq.verify_present_private_data()
-            .map_err(|e| Arc::new(e.into()))
+
+        Ok(rfq.verify_present_private_data()?)
     }
 }
 

--- a/bindings/tbdex_uniffi/src/resources/balance.rs
+++ b/bindings/tbdex_uniffi/src/resources/balance.rs
@@ -12,13 +12,14 @@ impl Balance {
         data: BalanceData,
         protocol: String,
     ) -> Result<Self> {
-        let inner_balance = InnerBalance::new(&bearer_did.0.clone(), &from, &data, &protocol)
-            .map_err(|e| Arc::new(e.into()))?;
+        let inner_balance = InnerBalance::new(&bearer_did.0.clone(), &from, &data, &protocol)?;
+
         Ok(Self(Arc::new(RwLock::new(inner_balance))))
     }
 
     pub fn from_json_string(json: &str) -> Result<Self> {
-        let inner_balance = InnerBalance::from_json_string(json).map_err(|e| Arc::new(e.into()))?;
+        let inner_balance = InnerBalance::from_json_string(json)?;
+
         Ok(Self(Arc::new(RwLock::new(inner_balance))))
     }
 
@@ -27,7 +28,8 @@ impl Balance {
             .0
             .read()
             .map_err(|e| RustCoreError::from_poison_error(e, "RwLockReadError"))?;
-        inner_balance.to_json().map_err(|e| Arc::new(e.into()))
+
+        Ok(inner_balance.to_json()?)
     }
 
     pub fn get_data(&self) -> Result<InnerBalance> {
@@ -35,6 +37,7 @@ impl Balance {
             .0
             .read()
             .map_err(|e| RustCoreError::from_poison_error(e, "RwLockReadError"))?;
+
         Ok(balance.clone())
     }
 }

--- a/bindings/tbdex_uniffi/src/resources/offering.rs
+++ b/bindings/tbdex_uniffi/src/resources/offering.rs
@@ -12,16 +12,13 @@ impl Offering {
         json_serialized_data: String,
         protocol: String,
     ) -> Result<Self> {
-        let data = serde_json::from_str::<InnerOfferingData>(&json_serialized_data)
-            .map_err(|e| Arc::new(e.into()))?;
-        let inner_offering = InnerOffering::new(&bearer_did.0.clone(), &from, &data, &protocol)
-            .map_err(|e| Arc::new(e.into()))?;
+        let data = serde_json::from_str::<InnerOfferingData>(&json_serialized_data)?;
+        let inner_offering = InnerOffering::new(&bearer_did.0.clone(), &from, &data, &protocol)?;
         Ok(Self(Arc::new(RwLock::new(inner_offering))))
     }
 
     pub fn from_json_string(json: &str) -> Result<Self> {
-        let inner_offering =
-            InnerOffering::from_json_string(json).map_err(|e| Arc::new(e.into()))?;
+        let inner_offering = InnerOffering::from_json_string(json)?;
         Ok(Self(Arc::new(RwLock::new(inner_offering))))
     }
 
@@ -30,7 +27,8 @@ impl Offering {
             .0
             .read()
             .map_err(|e| RustCoreError::from_poison_error(e, "RwLockReadError"))?;
-        inner_offering.to_json().map_err(|e| Arc::new(e.into()))
+
+        Ok(inner_offering.to_json()?)
     }
 
     pub fn get_data(&self) -> Result<data::Offering> {
@@ -38,8 +36,7 @@ impl Offering {
             .0
             .read()
             .map_err(|e| RustCoreError::from_poison_error(e, "RwLockReadError"))?;
-        let json_serialized_data =
-            serde_json::to_string(&inner_offering.data.clone()).map_err(|e| Arc::new(e.into()))?;
+        let json_serialized_data = serde_json::to_string(&inner_offering.data.clone())?;
         Ok(data::Offering {
             metadata: inner_offering.metadata.clone(),
             json_serialized_data,

--- a/bindings/tbdex_uniffi/src/tbdex.udl
+++ b/bindings/tbdex_uniffi/src/tbdex.udl
@@ -15,10 +15,9 @@ namespace tbdex {
   sequence<string> get_exchanges(string pfi_did_uri, BearerDid bearer_did);
 };
 
+[Error]
 interface RustCoreError {
-  string error_type();
-  string variant();
-  string message();
+  Error(string type, string variant, string msg);
 };
 
 enum ResourceKind {

--- a/bindings/tbdex_uniffi/src/tbdex.udl
+++ b/bindings/tbdex_uniffi/src/tbdex.udl
@@ -286,19 +286,18 @@ dictionary ServiceData {
   sequence<string> service_endpoint;
 };
 
+[Error]
 interface Web5RustCoreError {
-  string error_type();
-  string variant();
-  string message();
+  Error(string type, string variant, string msg);
 };
 
-[Trait]
+[Trait, WithForeign]
 interface Signer {
   [Throws=Web5RustCoreError]
-  bytes sign([ByRef] sequence<u8> payload);
+  bytes sign(bytes payload);
 };
 
-[Trait]
+[Trait, WithForeign]
 interface KeyManager {
   [Throws=Web5RustCoreError]
   Signer get_signer(JwkData public_jwk);

--- a/bound/kt/src/main/kotlin/tbdex/sdk/rust/tbdex.kt
+++ b/bound/kt/src/main/kotlin/tbdex/sdk/rust/tbdex.kt
@@ -856,20 +856,6 @@ internal open class UniffiVTableCallbackInterfaceSigner(
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 // A JNA Library to expose the extern-C FFI definitions.
 // This is an implementation detail which will be called internally by the public API.
 
@@ -885,6 +871,8 @@ internal interface UniffiLib : Library {
             val lib = Native.load(libraryPath.toString(), UniffiLib::class.java)
             lib.also {                uniffiCheckContractApiVersion(lib)
                 uniffiCheckApiChecksums(lib)
+                uniffiCallbackInterfaceKeyManager.register(lib)
+                uniffiCallbackInterfaceSigner.register(lib)
                 }
         }
         
@@ -943,6 +931,8 @@ internal interface UniffiLib : Library {
     fun uniffi_tbdex_uniffi_fn_clone_keymanager(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
     ): Pointer
     fun uniffi_tbdex_uniffi_fn_free_keymanager(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
+    ): Unit
+    fun uniffi_tbdex_uniffi_fn_init_callback_vtable_keymanager(`vtable`: UniffiVTableCallbackInterfaceKeyManager,
     ): Unit
     fun uniffi_tbdex_uniffi_fn_method_keymanager_get_signer(`ptr`: Pointer,`publicJwk`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): Pointer
@@ -1022,31 +1012,13 @@ internal interface UniffiLib : Library {
     ): Byte
     fun uniffi_tbdex_uniffi_fn_method_rfq_verify_present_private_data(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
     ): Byte
-    fun uniffi_tbdex_uniffi_fn_clone_rustcoreerror(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
-    ): Pointer
-    fun uniffi_tbdex_uniffi_fn_free_rustcoreerror(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
-    ): Unit
-    fun uniffi_tbdex_uniffi_fn_method_rustcoreerror_error_type(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
-    ): RustBuffer.ByValue
-    fun uniffi_tbdex_uniffi_fn_method_rustcoreerror_message(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
-    ): RustBuffer.ByValue
-    fun uniffi_tbdex_uniffi_fn_method_rustcoreerror_variant(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
-    ): RustBuffer.ByValue
     fun uniffi_tbdex_uniffi_fn_clone_signer(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
     ): Pointer
     fun uniffi_tbdex_uniffi_fn_free_signer(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
     ): Unit
-    fun uniffi_tbdex_uniffi_fn_method_signer_sign(`ptr`: Pointer,`payload`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
-    ): RustBuffer.ByValue
-    fun uniffi_tbdex_uniffi_fn_clone_web5rustcoreerror(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
-    ): Pointer
-    fun uniffi_tbdex_uniffi_fn_free_web5rustcoreerror(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
+    fun uniffi_tbdex_uniffi_fn_init_callback_vtable_signer(`vtable`: UniffiVTableCallbackInterfaceSigner,
     ): Unit
-    fun uniffi_tbdex_uniffi_fn_method_web5rustcoreerror_error_type(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
-    ): RustBuffer.ByValue
-    fun uniffi_tbdex_uniffi_fn_method_web5rustcoreerror_message(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
-    ): RustBuffer.ByValue
-    fun uniffi_tbdex_uniffi_fn_method_web5rustcoreerror_variant(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
+    fun uniffi_tbdex_uniffi_fn_method_signer_sign(`ptr`: Pointer,`payload`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
     fun uniffi_tbdex_uniffi_fn_func_create_exchange(`rfq`: Pointer,`replyTo`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): Unit
@@ -1238,19 +1210,7 @@ internal interface UniffiLib : Library {
     ): Short
     fun uniffi_tbdex_uniffi_checksum_method_rfq_verify_present_private_data(
     ): Short
-    fun uniffi_tbdex_uniffi_checksum_method_rustcoreerror_error_type(
-    ): Short
-    fun uniffi_tbdex_uniffi_checksum_method_rustcoreerror_message(
-    ): Short
-    fun uniffi_tbdex_uniffi_checksum_method_rustcoreerror_variant(
-    ): Short
     fun uniffi_tbdex_uniffi_checksum_method_signer_sign(
-    ): Short
-    fun uniffi_tbdex_uniffi_checksum_method_web5rustcoreerror_error_type(
-    ): Short
-    fun uniffi_tbdex_uniffi_checksum_method_web5rustcoreerror_message(
-    ): Short
-    fun uniffi_tbdex_uniffi_checksum_method_web5rustcoreerror_variant(
     ): Short
     fun uniffi_tbdex_uniffi_checksum_constructor_balance_from_json_string(
     ): Short
@@ -1303,172 +1263,154 @@ private fun uniffiCheckContractApiVersion(lib: UniffiLib) {
 
 @Suppress("UNUSED_PARAMETER")
 private fun uniffiCheckApiChecksums(lib: UniffiLib) {
-    if (lib.uniffi_tbdex_uniffi_checksum_func_create_exchange() != 7308.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_func_create_exchange() != 58018.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_func_get_balances() != 51715.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_func_get_balances() != 10312.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_func_get_exchange() != 12075.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_func_get_exchange() != 4922.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_func_get_exchanges() != 41220.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_func_get_exchanges() != 5099.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_func_get_offerings() != 20626.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_func_get_offerings() != 56237.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_func_submit_close() != 11219.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_func_submit_close() != 44816.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_func_submit_order() != 22522.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_func_submit_order() != 43235.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_method_balance_get_data() != 45636.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_method_balance_get_data() != 62619.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_method_balance_to_json() != 2963.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_method_balance_to_json() != 58786.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_tbdex_uniffi_checksum_method_bearerdid_get_data() != 7101.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_method_bearerdid_get_signer() != 48151.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_method_bearerdid_get_signer() != 22456.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_method_close_get_data() != 42568.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_method_close_get_data() != 28213.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_method_close_to_json() != 63038.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_method_close_to_json() != 19365.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_method_inmemorykeymanager_get_as_key_manager() != 4734.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_method_inmemorykeymanager_get_as_key_manager() != 181.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_method_inmemorykeymanager_get_signer() != 53772.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_method_inmemorykeymanager_get_signer() != 36148.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_method_inmemorykeymanager_import_private_jwk() != 48963.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_method_inmemorykeymanager_import_private_jwk() != 3278.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_method_keymanager_get_signer() != 33675.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_method_keymanager_get_signer() != 55674.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_method_offering_get_data() != 54801.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_method_offering_get_data() != 51981.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_method_offering_to_json() != 24105.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_method_offering_to_json() != 6629.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_method_order_get_data() != 46414.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_method_order_get_data() != 22510.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_method_order_to_json() != 64999.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_method_order_to_json() != 53626.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_method_orderstatus_get_data() != 32040.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_method_orderstatus_get_data() != 64681.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_method_orderstatus_to_json() != 42316.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_method_orderstatus_to_json() != 35902.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_method_presentationdefinition_get_json_serialized_presentation_definition() != 59402.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_method_presentationdefinition_get_json_serialized_presentation_definition() != 16906.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_method_presentationdefinition_select_credentials() != 2690.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_method_presentationdefinition_select_credentials() != 31180.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_method_quote_get_data() != 23104.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_method_quote_get_data() != 16879.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_method_quote_to_json() != 20930.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_method_quote_to_json() != 37615.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_method_rfq_get_data() != 45129.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_method_rfq_get_data() != 47828.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_method_rfq_to_json() != 56973.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_method_rfq_to_json() != 46345.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_method_rfq_verify_all_private_data() != 54169.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_method_rfq_verify_all_private_data() != 56842.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_method_rfq_verify_offering_requirements() != 64928.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_method_rfq_verify_offering_requirements() != 20586.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_method_rfq_verify_present_private_data() != 57252.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_method_rfq_verify_present_private_data() != 31783.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_method_rustcoreerror_error_type() != 26968.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_method_signer_sign() != 42600.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_method_rustcoreerror_message() != 41308.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_constructor_balance_from_json_string() != 58225.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_method_rustcoreerror_variant() != 585.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_constructor_balance_new() != 21130.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_method_signer_sign() != 20840.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_constructor_bearerdid_new() != 33593.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_method_web5rustcoreerror_error_type() != 50948.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_constructor_close_from_json_string() != 31628.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_method_web5rustcoreerror_message() != 54823.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_tbdex_uniffi_checksum_method_web5rustcoreerror_variant() != 12994.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_tbdex_uniffi_checksum_constructor_balance_from_json_string() != 47556.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_tbdex_uniffi_checksum_constructor_balance_new() != 49171.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_tbdex_uniffi_checksum_constructor_bearerdid_new() != 8830.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_tbdex_uniffi_checksum_constructor_close_from_json_string() != 64811.toShort()) {
-        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    }
-    if (lib.uniffi_tbdex_uniffi_checksum_constructor_close_new() != 7037.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_constructor_close_new() != 39292.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_tbdex_uniffi_checksum_constructor_inmemorykeymanager_new() != 52263.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_constructor_offering_from_json_string() != 21018.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_constructor_offering_from_json_string() != 61646.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_constructor_offering_new() != 34222.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_constructor_offering_new() != 60046.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_constructor_order_from_json_string() != 63305.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_constructor_order_from_json_string() != 60642.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_constructor_order_new() != 26328.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_constructor_order_new() != 12888.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_constructor_orderstatus_from_json_string() != 11447.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_constructor_orderstatus_from_json_string() != 3049.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_constructor_orderstatus_new() != 5401.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_constructor_orderstatus_new() != 34207.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_constructor_presentationdefinition_new() != 29523.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_constructor_presentationdefinition_new() != 62739.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_constructor_quote_from_json_string() != 59989.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_constructor_quote_from_json_string() != 8299.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_constructor_quote_new() != 24782.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_constructor_quote_new() != 62621.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_constructor_rfq_from_json_string() != 45885.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_constructor_rfq_from_json_string() != 4210.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_constructor_rfq_new() != 5327.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_constructor_rfq_new() != 42025.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
 }
@@ -1510,26 +1452,6 @@ inline fun <T : Disposable?, R> T.use(block: (T) -> R) =
 
 /** Used to instantiate an interface without an actual pointer, for fakes in tests, mostly. */
 object NoPointer
-
-public object FfiConverterUByte: FfiConverter<UByte, Byte> {
-    override fun lift(value: Byte): UByte {
-        return value.toUByte()
-    }
-
-    override fun read(buf: ByteBuffer): UByte {
-        return lift(buf.get())
-    }
-
-    override fun lower(value: UByte): Byte {
-        return value.toByte()
-    }
-
-    override fun allocationSize(value: UByte) = 1UL
-
-    override fun write(value: UByte, buf: ByteBuffer) {
-        buf.put(value.toByte())
-    }
-}
 
 public object FfiConverterBoolean: FfiConverter<Boolean, Byte> {
     override fun lift(value: Byte): Boolean {
@@ -2836,14 +2758,14 @@ public object FfiConverterTypeInMemoryKeyManager: FfiConverter<InMemoryKeyManage
 //
 
 
-public interface KeyManagerInterface {
+public interface KeyManager {
     
     fun `getSigner`(`publicJwk`: JwkData): Signer
     
     companion object
 }
 
-open class KeyManager: Disposable, AutoCloseable, KeyManagerInterface {
+open class KeyManagerImpl: Disposable, AutoCloseable, KeyManager {
 
     constructor(pointer: Pointer) {
         this.pointer = pointer
@@ -2944,15 +2866,83 @@ open class KeyManager: Disposable, AutoCloseable, KeyManagerInterface {
     companion object
     
 }
+// Magic number for the Rust proxy to call using the same mechanism as every other method,
+// to free the callback once it's dropped by Rust.
+internal const val IDX_CALLBACK_FREE = 0
+// Callback return codes
+internal const val UNIFFI_CALLBACK_SUCCESS = 0
+internal const val UNIFFI_CALLBACK_ERROR = 1
+internal const val UNIFFI_CALLBACK_UNEXPECTED_ERROR = 2
+
+public abstract class FfiConverterCallbackInterface<CallbackInterface: Any>: FfiConverter<CallbackInterface, Long> {
+    internal val handleMap = UniffiHandleMap<CallbackInterface>()
+
+    internal fun drop(handle: Long) {
+        handleMap.remove(handle)
+    }
+
+    override fun lift(value: Long): CallbackInterface {
+        return handleMap.get(value)
+    }
+
+    override fun read(buf: ByteBuffer) = lift(buf.getLong())
+
+    override fun lower(value: CallbackInterface) = handleMap.insert(value)
+
+    override fun allocationSize(value: CallbackInterface) = 8UL
+
+    override fun write(value: CallbackInterface, buf: ByteBuffer) {
+        buf.putLong(lower(value))
+    }
+}
+
+// Put the implementation in an object so we don't pollute the top-level namespace
+internal object uniffiCallbackInterfaceKeyManager {
+    internal object `getSigner`: UniffiCallbackInterfaceKeyManagerMethod0 {
+        override fun callback(`uniffiHandle`: Long,`publicJwk`: RustBuffer.ByValue,`uniffiOutReturn`: PointerByReference,uniffiCallStatus: UniffiRustCallStatus,) {
+            val uniffiObj = FfiConverterTypeKeyManager.handleMap.get(uniffiHandle)
+            val makeCall = { ->
+                uniffiObj.`getSigner`(
+                    FfiConverterTypeJwkData.lift(`publicJwk`),
+                )
+            }
+            val writeReturn = { value: Signer -> uniffiOutReturn.setValue(FfiConverterTypeSigner.lower(value)) }
+            uniffiTraitInterfaceCallWithError(
+                uniffiCallStatus,
+                makeCall,
+                writeReturn,
+                { e: Web5RustCoreException -> FfiConverterTypeWeb5RustCoreError.lower(e) }
+            )
+        }
+    }
+
+    internal object uniffiFree: UniffiCallbackInterfaceFree {
+        override fun callback(handle: Long) {
+            FfiConverterTypeKeyManager.handleMap.remove(handle)
+        }
+    }
+
+    internal var vtable = UniffiVTableCallbackInterfaceKeyManager.UniffiByValue(
+        `getSigner`,
+        uniffiFree,
+    )
+
+    // Registers the foreign callback with the Rust side.
+    // This method is generated for each callback interface.
+    internal fun register(lib: UniffiLib) {
+        lib.uniffi_tbdex_uniffi_fn_init_callback_vtable_keymanager(vtable)
+    }
+}
 
 public object FfiConverterTypeKeyManager: FfiConverter<KeyManager, Pointer> {
+    internal val handleMap = UniffiHandleMap<KeyManager>()
 
     override fun lower(value: KeyManager): Pointer {
-        return value.uniffiClonePointer()
+        return Pointer(handleMap.insert(value))
     }
 
     override fun lift(value: Pointer): KeyManager {
-        return KeyManager(value)
+        return KeyManagerImpl(value)
     }
 
     override fun read(buf: ByteBuffer): KeyManager {
@@ -4704,285 +4694,14 @@ public object FfiConverterTypeRfq: FfiConverter<Rfq, Pointer> {
 //
 
 
-public interface RustCoreExceptionInterface {
+public interface Signer {
     
-    fun `errorType`(): kotlin.String
-    
-    fun `message`(): kotlin.String
-    
-    fun `variant`(): kotlin.String
+    fun `sign`(`payload`: kotlin.ByteArray): kotlin.ByteArray
     
     companion object
 }
 
-
-open class RustCoreException : Exception, Disposable, AutoCloseable, RustCoreExceptionInterface {
-
-
-    constructor(pointer: Pointer) {
-        this.pointer = pointer
-        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(pointer))
-    }
-
-    /**
-     * This constructor can be used to instantiate a fake object. Only used for tests. Any
-     * attempt to actually use an object constructed this way will fail as there is no
-     * connected Rust object.
-     */
-    @Suppress("UNUSED_PARAMETER")
-    constructor(noPointer: NoPointer) {
-        this.pointer = null
-        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(pointer))
-    }
-
-    protected val pointer: Pointer?
-    protected val cleanable: UniffiCleaner.Cleanable
-
-    private val wasDestroyed = AtomicBoolean(false)
-    private val callCounter = AtomicLong(1)
-
-    override fun destroy() {
-        // Only allow a single call to this method.
-        // TODO: maybe we should log a warning if called more than once?
-        if (this.wasDestroyed.compareAndSet(false, true)) {
-            // This decrement always matches the initial count of 1 given at creation time.
-            if (this.callCounter.decrementAndGet() == 0L) {
-                cleanable.clean()
-            }
-        }
-    }
-
-    @Synchronized
-    override fun close() {
-        this.destroy()
-    }
-
-    internal inline fun <R> callWithPointer(block: (ptr: Pointer) -> R): R {
-        // Check and increment the call counter, to keep the object alive.
-        // This needs a compare-and-set retry loop in case of concurrent updates.
-        do {
-            val c = this.callCounter.get()
-            if (c == 0L) {
-                throw IllegalStateException("${this.javaClass.simpleName} object has already been destroyed")
-            }
-            if (c == Long.MAX_VALUE) {
-                throw IllegalStateException("${this.javaClass.simpleName} call counter would overflow")
-            }
-        } while (! this.callCounter.compareAndSet(c, c + 1L))
-        // Now we can safely do the method call without the pointer being freed concurrently.
-        try {
-            return block(this.uniffiClonePointer())
-        } finally {
-            // This decrement always matches the increment we performed above.
-            if (this.callCounter.decrementAndGet() == 0L) {
-                cleanable.clean()
-            }
-        }
-    }
-
-    // Use a static inner class instead of a closure so as not to accidentally
-    // capture `this` as part of the cleanable's action.
-    private class UniffiCleanAction(private val pointer: Pointer?) : Runnable {
-        override fun run() {
-            pointer?.let { ptr ->
-                uniffiRustCall { status ->
-                    UniffiLib.INSTANCE.uniffi_tbdex_uniffi_fn_free_rustcoreerror(ptr, status)
-                }
-            }
-        }
-    }
-
-    fun uniffiClonePointer(): Pointer {
-        return uniffiRustCall() { status ->
-            UniffiLib.INSTANCE.uniffi_tbdex_uniffi_fn_clone_rustcoreerror(pointer!!, status)
-        }
-    }
-
-    override fun `errorType`(): kotlin.String {
-            return FfiConverterString.lift(
-    callWithPointer {
-    uniffiRustCall() { _status ->
-    UniffiLib.INSTANCE.uniffi_tbdex_uniffi_fn_method_rustcoreerror_error_type(
-        it, _status)
-}
-    }
-    )
-    }
-    
-
-    override fun `message`(): kotlin.String {
-            return FfiConverterString.lift(
-    callWithPointer {
-    uniffiRustCall() { _status ->
-    UniffiLib.INSTANCE.uniffi_tbdex_uniffi_fn_method_rustcoreerror_message(
-        it, _status)
-}
-    }
-    )
-    }
-    
-
-    override fun `variant`(): kotlin.String {
-            return FfiConverterString.lift(
-    callWithPointer {
-    uniffiRustCall() { _status ->
-    UniffiLib.INSTANCE.uniffi_tbdex_uniffi_fn_method_rustcoreerror_variant(
-        it, _status)
-}
-    }
-    )
-    }
-    
-
-    
-
-    
-    
-    companion object ErrorHandler : UniffiRustCallStatusErrorHandler<RustCoreException> {
-        override fun lift(error_buf: RustBuffer.ByValue): RustCoreException {
-            // Due to some mismatches in the ffi converter mechanisms, errors are a RustBuffer.
-            val bb = error_buf.asByteBuffer()
-            if (bb == null) {
-                throw InternalException("?")
-            }
-            return FfiConverterTypeRustCoreError.read(bb)
-        }
-    }
-    
-}
-
-public object FfiConverterTypeRustCoreError: FfiConverter<RustCoreException, Pointer> {
-
-    override fun lower(value: RustCoreException): Pointer {
-        return value.uniffiClonePointer()
-    }
-
-    override fun lift(value: Pointer): RustCoreException {
-        return RustCoreException(value)
-    }
-
-    override fun read(buf: ByteBuffer): RustCoreException {
-        // The Rust code always writes pointers as 8 bytes, and will
-        // fail to compile if they don't fit.
-        return lift(Pointer(buf.getLong()))
-    }
-
-    override fun allocationSize(value: RustCoreException) = 8UL
-
-    override fun write(value: RustCoreException, buf: ByteBuffer) {
-        // The Rust code always expects pointers written as 8 bytes,
-        // and will fail to compile if they don't fit.
-        buf.putLong(Pointer.nativeValue(lower(value)))
-    }
-}
-
-
-// This template implements a class for working with a Rust struct via a Pointer/Arc<T>
-// to the live Rust struct on the other side of the FFI.
-//
-// Each instance implements core operations for working with the Rust `Arc<T>` and the
-// Kotlin Pointer to work with the live Rust struct on the other side of the FFI.
-//
-// There's some subtlety here, because we have to be careful not to operate on a Rust
-// struct after it has been dropped, and because we must expose a public API for freeing
-// theq Kotlin wrapper object in lieu of reliable finalizers. The core requirements are:
-//
-//   * Each instance holds an opaque pointer to the underlying Rust struct.
-//     Method calls need to read this pointer from the object's state and pass it in to
-//     the Rust FFI.
-//
-//   * When an instance is no longer needed, its pointer should be passed to a
-//     special destructor function provided by the Rust FFI, which will drop the
-//     underlying Rust struct.
-//
-//   * Given an instance, calling code is expected to call the special
-//     `destroy` method in order to free it after use, either by calling it explicitly
-//     or by using a higher-level helper like the `use` method. Failing to do so risks
-//     leaking the underlying Rust struct.
-//
-//   * We can't assume that calling code will do the right thing, and must be prepared
-//     to handle Kotlin method calls executing concurrently with or even after a call to
-//     `destroy`, and to handle multiple (possibly concurrent!) calls to `destroy`.
-//
-//   * We must never allow Rust code to operate on the underlying Rust struct after
-//     the destructor has been called, and must never call the destructor more than once.
-//     Doing so may trigger memory unsafety.
-//
-//   * To mitigate many of the risks of leaking memory and use-after-free unsafety, a `Cleaner`
-//     is implemented to call the destructor when the Kotlin object becomes unreachable.
-//     This is done in a background thread. This is not a panacea, and client code should be aware that
-//      1. the thread may starve if some there are objects that have poorly performing
-//     `drop` methods or do significant work in their `drop` methods.
-//      2. the thread is shared across the whole library. This can be tuned by using `android_cleaner = true`,
-//         or `android = true` in the [`kotlin` section of the `uniffi.toml` file](https://mozilla.github.io/uniffi-rs/kotlin/configuration.html).
-//
-// If we try to implement this with mutual exclusion on access to the pointer, there is the
-// possibility of a race between a method call and a concurrent call to `destroy`:
-//
-//    * Thread A starts a method call, reads the value of the pointer, but is interrupted
-//      before it can pass the pointer over the FFI to Rust.
-//    * Thread B calls `destroy` and frees the underlying Rust struct.
-//    * Thread A resumes, passing the already-read pointer value to Rust and triggering
-//      a use-after-free.
-//
-// One possible solution would be to use a `ReadWriteLock`, with each method call taking
-// a read lock (and thus allowed to run concurrently) and the special `destroy` method
-// taking a write lock (and thus blocking on live method calls). However, we aim not to
-// generate methods with any hidden blocking semantics, and a `destroy` method that might
-// block if called incorrectly seems to meet that bar.
-//
-// So, we achieve our goals by giving each instance an associated `AtomicLong` counter to track
-// the number of in-flight method calls, and an `AtomicBoolean` flag to indicate whether `destroy`
-// has been called. These are updated according to the following rules:
-//
-//    * The initial value of the counter is 1, indicating a live object with no in-flight calls.
-//      The initial value for the flag is false.
-//
-//    * At the start of each method call, we atomically check the counter.
-//      If it is 0 then the underlying Rust struct has already been destroyed and the call is aborted.
-//      If it is nonzero them we atomically increment it by 1 and proceed with the method call.
-//
-//    * At the end of each method call, we atomically decrement and check the counter.
-//      If it has reached zero then we destroy the underlying Rust struct.
-//
-//    * When `destroy` is called, we atomically flip the flag from false to true.
-//      If the flag was already true we silently fail.
-//      Otherwise we atomically decrement and check the counter.
-//      If it has reached zero then we destroy the underlying Rust struct.
-//
-// Astute readers may observe that this all sounds very similar to the way that Rust's `Arc<T>` works,
-// and indeed it is, with the addition of a flag to guard against multiple calls to `destroy`.
-//
-// The overall effect is that the underlying Rust struct is destroyed only when `destroy` has been
-// called *and* all in-flight method calls have completed, avoiding violating any of the expectations
-// of the underlying Rust code.
-//
-// This makes a cleaner a better alternative to _not_ calling `destroy()` as
-// and when the object is finished with, but the abstraction is not perfect: if the Rust object's `drop`
-// method is slow, and/or there are many objects to cleanup, and it's on a low end Android device, then the cleaner
-// thread may be starved, and the app will leak memory.
-//
-// In this case, `destroy`ing manually may be a better solution.
-//
-// The cleaner can live side by side with the manual calling of `destroy`. In the order of responsiveness, uniffi objects
-// with Rust peers are reclaimed:
-//
-// 1. By calling the `destroy` method of the object, which calls `rustObject.free()`. If that doesn't happen:
-// 2. When the object becomes unreachable, AND the Cleaner thread gets to call `rustObject.free()`. If the thread is starved then:
-// 3. The memory is reclaimed when the process terminates.
-//
-// [1] https://stackoverflow.com/questions/24376768/can-java-finalize-an-object-when-it-is-still-in-scope/24380219
-//
-
-
-public interface SignerInterface {
-    
-    fun `sign`(`payload`: List<kotlin.UByte>): kotlin.ByteArray
-    
-    companion object
-}
-
-open class Signer: Disposable, AutoCloseable, SignerInterface {
+open class SignerImpl: Disposable, AutoCloseable, Signer {
 
     constructor(pointer: Pointer) {
         this.pointer = pointer
@@ -5064,12 +4783,12 @@ open class Signer: Disposable, AutoCloseable, SignerInterface {
     }
 
     
-    @Throws(Web5RustCoreException::class)override fun `sign`(`payload`: List<kotlin.UByte>): kotlin.ByteArray {
+    @Throws(Web5RustCoreException::class)override fun `sign`(`payload`: kotlin.ByteArray): kotlin.ByteArray {
             return FfiConverterByteArray.lift(
     callWithPointer {
     uniffiRustCallWithError(Web5RustCoreException) { _status ->
     UniffiLib.INSTANCE.uniffi_tbdex_uniffi_fn_method_signer_sign(
-        it, FfiConverterSequenceUByte.lower(`payload`),_status)
+        it, FfiConverterByteArray.lower(`payload`),_status)
 }
     }
     )
@@ -5084,14 +4803,54 @@ open class Signer: Disposable, AutoCloseable, SignerInterface {
     
 }
 
+
+// Put the implementation in an object so we don't pollute the top-level namespace
+internal object uniffiCallbackInterfaceSigner {
+    internal object `sign`: UniffiCallbackInterfaceSignerMethod0 {
+        override fun callback(`uniffiHandle`: Long,`payload`: RustBuffer.ByValue,`uniffiOutReturn`: RustBuffer,uniffiCallStatus: UniffiRustCallStatus,) {
+            val uniffiObj = FfiConverterTypeSigner.handleMap.get(uniffiHandle)
+            val makeCall = { ->
+                uniffiObj.`sign`(
+                    FfiConverterByteArray.lift(`payload`),
+                )
+            }
+            val writeReturn = { value: kotlin.ByteArray -> uniffiOutReturn.setValue(FfiConverterByteArray.lower(value)) }
+            uniffiTraitInterfaceCallWithError(
+                uniffiCallStatus,
+                makeCall,
+                writeReturn,
+                { e: Web5RustCoreException -> FfiConverterTypeWeb5RustCoreError.lower(e) }
+            )
+        }
+    }
+
+    internal object uniffiFree: UniffiCallbackInterfaceFree {
+        override fun callback(handle: Long) {
+            FfiConverterTypeSigner.handleMap.remove(handle)
+        }
+    }
+
+    internal var vtable = UniffiVTableCallbackInterfaceSigner.UniffiByValue(
+        `sign`,
+        uniffiFree,
+    )
+
+    // Registers the foreign callback with the Rust side.
+    // This method is generated for each callback interface.
+    internal fun register(lib: UniffiLib) {
+        lib.uniffi_tbdex_uniffi_fn_init_callback_vtable_signer(vtable)
+    }
+}
+
 public object FfiConverterTypeSigner: FfiConverter<Signer, Pointer> {
+    internal val handleMap = UniffiHandleMap<Signer>()
 
     override fun lower(value: Signer): Pointer {
-        return value.uniffiClonePointer()
+        return Pointer(handleMap.insert(value))
     }
 
     override fun lift(value: Pointer): Signer {
-        return Signer(value)
+        return SignerImpl(value)
     }
 
     override fun read(buf: ByteBuffer): Signer {
@@ -5103,277 +4862,6 @@ public object FfiConverterTypeSigner: FfiConverter<Signer, Pointer> {
     override fun allocationSize(value: Signer) = 8UL
 
     override fun write(value: Signer, buf: ByteBuffer) {
-        // The Rust code always expects pointers written as 8 bytes,
-        // and will fail to compile if they don't fit.
-        buf.putLong(Pointer.nativeValue(lower(value)))
-    }
-}
-
-
-// This template implements a class for working with a Rust struct via a Pointer/Arc<T>
-// to the live Rust struct on the other side of the FFI.
-//
-// Each instance implements core operations for working with the Rust `Arc<T>` and the
-// Kotlin Pointer to work with the live Rust struct on the other side of the FFI.
-//
-// There's some subtlety here, because we have to be careful not to operate on a Rust
-// struct after it has been dropped, and because we must expose a public API for freeing
-// theq Kotlin wrapper object in lieu of reliable finalizers. The core requirements are:
-//
-//   * Each instance holds an opaque pointer to the underlying Rust struct.
-//     Method calls need to read this pointer from the object's state and pass it in to
-//     the Rust FFI.
-//
-//   * When an instance is no longer needed, its pointer should be passed to a
-//     special destructor function provided by the Rust FFI, which will drop the
-//     underlying Rust struct.
-//
-//   * Given an instance, calling code is expected to call the special
-//     `destroy` method in order to free it after use, either by calling it explicitly
-//     or by using a higher-level helper like the `use` method. Failing to do so risks
-//     leaking the underlying Rust struct.
-//
-//   * We can't assume that calling code will do the right thing, and must be prepared
-//     to handle Kotlin method calls executing concurrently with or even after a call to
-//     `destroy`, and to handle multiple (possibly concurrent!) calls to `destroy`.
-//
-//   * We must never allow Rust code to operate on the underlying Rust struct after
-//     the destructor has been called, and must never call the destructor more than once.
-//     Doing so may trigger memory unsafety.
-//
-//   * To mitigate many of the risks of leaking memory and use-after-free unsafety, a `Cleaner`
-//     is implemented to call the destructor when the Kotlin object becomes unreachable.
-//     This is done in a background thread. This is not a panacea, and client code should be aware that
-//      1. the thread may starve if some there are objects that have poorly performing
-//     `drop` methods or do significant work in their `drop` methods.
-//      2. the thread is shared across the whole library. This can be tuned by using `android_cleaner = true`,
-//         or `android = true` in the [`kotlin` section of the `uniffi.toml` file](https://mozilla.github.io/uniffi-rs/kotlin/configuration.html).
-//
-// If we try to implement this with mutual exclusion on access to the pointer, there is the
-// possibility of a race between a method call and a concurrent call to `destroy`:
-//
-//    * Thread A starts a method call, reads the value of the pointer, but is interrupted
-//      before it can pass the pointer over the FFI to Rust.
-//    * Thread B calls `destroy` and frees the underlying Rust struct.
-//    * Thread A resumes, passing the already-read pointer value to Rust and triggering
-//      a use-after-free.
-//
-// One possible solution would be to use a `ReadWriteLock`, with each method call taking
-// a read lock (and thus allowed to run concurrently) and the special `destroy` method
-// taking a write lock (and thus blocking on live method calls). However, we aim not to
-// generate methods with any hidden blocking semantics, and a `destroy` method that might
-// block if called incorrectly seems to meet that bar.
-//
-// So, we achieve our goals by giving each instance an associated `AtomicLong` counter to track
-// the number of in-flight method calls, and an `AtomicBoolean` flag to indicate whether `destroy`
-// has been called. These are updated according to the following rules:
-//
-//    * The initial value of the counter is 1, indicating a live object with no in-flight calls.
-//      The initial value for the flag is false.
-//
-//    * At the start of each method call, we atomically check the counter.
-//      If it is 0 then the underlying Rust struct has already been destroyed and the call is aborted.
-//      If it is nonzero them we atomically increment it by 1 and proceed with the method call.
-//
-//    * At the end of each method call, we atomically decrement and check the counter.
-//      If it has reached zero then we destroy the underlying Rust struct.
-//
-//    * When `destroy` is called, we atomically flip the flag from false to true.
-//      If the flag was already true we silently fail.
-//      Otherwise we atomically decrement and check the counter.
-//      If it has reached zero then we destroy the underlying Rust struct.
-//
-// Astute readers may observe that this all sounds very similar to the way that Rust's `Arc<T>` works,
-// and indeed it is, with the addition of a flag to guard against multiple calls to `destroy`.
-//
-// The overall effect is that the underlying Rust struct is destroyed only when `destroy` has been
-// called *and* all in-flight method calls have completed, avoiding violating any of the expectations
-// of the underlying Rust code.
-//
-// This makes a cleaner a better alternative to _not_ calling `destroy()` as
-// and when the object is finished with, but the abstraction is not perfect: if the Rust object's `drop`
-// method is slow, and/or there are many objects to cleanup, and it's on a low end Android device, then the cleaner
-// thread may be starved, and the app will leak memory.
-//
-// In this case, `destroy`ing manually may be a better solution.
-//
-// The cleaner can live side by side with the manual calling of `destroy`. In the order of responsiveness, uniffi objects
-// with Rust peers are reclaimed:
-//
-// 1. By calling the `destroy` method of the object, which calls `rustObject.free()`. If that doesn't happen:
-// 2. When the object becomes unreachable, AND the Cleaner thread gets to call `rustObject.free()`. If the thread is starved then:
-// 3. The memory is reclaimed when the process terminates.
-//
-// [1] https://stackoverflow.com/questions/24376768/can-java-finalize-an-object-when-it-is-still-in-scope/24380219
-//
-
-
-public interface Web5RustCoreExceptionInterface {
-    
-    fun `errorType`(): kotlin.String
-    
-    fun `message`(): kotlin.String
-    
-    fun `variant`(): kotlin.String
-    
-    companion object
-}
-
-
-open class Web5RustCoreException : Exception, Disposable, AutoCloseable, Web5RustCoreExceptionInterface {
-
-
-    constructor(pointer: Pointer) {
-        this.pointer = pointer
-        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(pointer))
-    }
-
-    /**
-     * This constructor can be used to instantiate a fake object. Only used for tests. Any
-     * attempt to actually use an object constructed this way will fail as there is no
-     * connected Rust object.
-     */
-    @Suppress("UNUSED_PARAMETER")
-    constructor(noPointer: NoPointer) {
-        this.pointer = null
-        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(pointer))
-    }
-
-    protected val pointer: Pointer?
-    protected val cleanable: UniffiCleaner.Cleanable
-
-    private val wasDestroyed = AtomicBoolean(false)
-    private val callCounter = AtomicLong(1)
-
-    override fun destroy() {
-        // Only allow a single call to this method.
-        // TODO: maybe we should log a warning if called more than once?
-        if (this.wasDestroyed.compareAndSet(false, true)) {
-            // This decrement always matches the initial count of 1 given at creation time.
-            if (this.callCounter.decrementAndGet() == 0L) {
-                cleanable.clean()
-            }
-        }
-    }
-
-    @Synchronized
-    override fun close() {
-        this.destroy()
-    }
-
-    internal inline fun <R> callWithPointer(block: (ptr: Pointer) -> R): R {
-        // Check and increment the call counter, to keep the object alive.
-        // This needs a compare-and-set retry loop in case of concurrent updates.
-        do {
-            val c = this.callCounter.get()
-            if (c == 0L) {
-                throw IllegalStateException("${this.javaClass.simpleName} object has already been destroyed")
-            }
-            if (c == Long.MAX_VALUE) {
-                throw IllegalStateException("${this.javaClass.simpleName} call counter would overflow")
-            }
-        } while (! this.callCounter.compareAndSet(c, c + 1L))
-        // Now we can safely do the method call without the pointer being freed concurrently.
-        try {
-            return block(this.uniffiClonePointer())
-        } finally {
-            // This decrement always matches the increment we performed above.
-            if (this.callCounter.decrementAndGet() == 0L) {
-                cleanable.clean()
-            }
-        }
-    }
-
-    // Use a static inner class instead of a closure so as not to accidentally
-    // capture `this` as part of the cleanable's action.
-    private class UniffiCleanAction(private val pointer: Pointer?) : Runnable {
-        override fun run() {
-            pointer?.let { ptr ->
-                uniffiRustCall { status ->
-                    UniffiLib.INSTANCE.uniffi_tbdex_uniffi_fn_free_web5rustcoreerror(ptr, status)
-                }
-            }
-        }
-    }
-
-    fun uniffiClonePointer(): Pointer {
-        return uniffiRustCall() { status ->
-            UniffiLib.INSTANCE.uniffi_tbdex_uniffi_fn_clone_web5rustcoreerror(pointer!!, status)
-        }
-    }
-
-    override fun `errorType`(): kotlin.String {
-            return FfiConverterString.lift(
-    callWithPointer {
-    uniffiRustCall() { _status ->
-    UniffiLib.INSTANCE.uniffi_tbdex_uniffi_fn_method_web5rustcoreerror_error_type(
-        it, _status)
-}
-    }
-    )
-    }
-    
-
-    override fun `message`(): kotlin.String {
-            return FfiConverterString.lift(
-    callWithPointer {
-    uniffiRustCall() { _status ->
-    UniffiLib.INSTANCE.uniffi_tbdex_uniffi_fn_method_web5rustcoreerror_message(
-        it, _status)
-}
-    }
-    )
-    }
-    
-
-    override fun `variant`(): kotlin.String {
-            return FfiConverterString.lift(
-    callWithPointer {
-    uniffiRustCall() { _status ->
-    UniffiLib.INSTANCE.uniffi_tbdex_uniffi_fn_method_web5rustcoreerror_variant(
-        it, _status)
-}
-    }
-    )
-    }
-    
-
-    
-
-    
-    
-    companion object ErrorHandler : UniffiRustCallStatusErrorHandler<Web5RustCoreException> {
-        override fun lift(error_buf: RustBuffer.ByValue): Web5RustCoreException {
-            // Due to some mismatches in the ffi converter mechanisms, errors are a RustBuffer.
-            val bb = error_buf.asByteBuffer()
-            if (bb == null) {
-                throw InternalException("?")
-            }
-            return FfiConverterTypeWeb5RustCoreError.read(bb)
-        }
-    }
-    
-}
-
-public object FfiConverterTypeWeb5RustCoreError: FfiConverter<Web5RustCoreException, Pointer> {
-
-    override fun lower(value: Web5RustCoreException): Pointer {
-        return value.uniffiClonePointer()
-    }
-
-    override fun lift(value: Pointer): Web5RustCoreException {
-        return Web5RustCoreException(value)
-    }
-
-    override fun read(buf: ByteBuffer): Web5RustCoreException {
-        // The Rust code always writes pointers as 8 bytes, and will
-        // fail to compile if they don't fit.
-        return lift(Pointer(buf.getLong()))
-    }
-
-    override fun allocationSize(value: Web5RustCoreException) = 8UL
-
-    override fun write(value: Web5RustCoreException, buf: ByteBuffer) {
         // The Rust code always expects pointers written as 8 bytes,
         // and will fail to compile if they don't fit.
         buf.putLong(Pointer.nativeValue(lower(value)))
@@ -6307,6 +5795,138 @@ public object FfiConverterTypeResourceKind: FfiConverterRustBuffer<ResourceKind>
 
 
 
+
+sealed class RustCoreException: Exception() {
+    
+    class Exception(
+        
+        val `type`: kotlin.String, 
+        
+        val `variant`: kotlin.String, 
+        
+        val `msg`: kotlin.String
+        ) : RustCoreException() {
+        override val message
+            get() = "type=${ `type` }, variant=${ `variant` }, msg=${ `msg` }"
+    }
+    
+
+    companion object ErrorHandler : UniffiRustCallStatusErrorHandler<RustCoreException> {
+        override fun lift(error_buf: RustBuffer.ByValue): RustCoreException = FfiConverterTypeRustCoreError.lift(error_buf)
+    }
+
+    
+}
+
+public object FfiConverterTypeRustCoreError : FfiConverterRustBuffer<RustCoreException> {
+    override fun read(buf: ByteBuffer): RustCoreException {
+        
+
+        return when(buf.getInt()) {
+            1 -> RustCoreException.Exception(
+                FfiConverterString.read(buf),
+                FfiConverterString.read(buf),
+                FfiConverterString.read(buf),
+                )
+            else -> throw RuntimeException("invalid error enum value, something is very wrong!!")
+        }
+    }
+
+    override fun allocationSize(value: RustCoreException): ULong {
+        return when(value) {
+            is RustCoreException.Exception -> (
+                // Add the size for the Int that specifies the variant plus the size needed for all fields
+                4UL
+                + FfiConverterString.allocationSize(value.`type`)
+                + FfiConverterString.allocationSize(value.`variant`)
+                + FfiConverterString.allocationSize(value.`msg`)
+            )
+        }
+    }
+
+    override fun write(value: RustCoreException, buf: ByteBuffer) {
+        when(value) {
+            is RustCoreException.Exception -> {
+                buf.putInt(1)
+                FfiConverterString.write(value.`type`, buf)
+                FfiConverterString.write(value.`variant`, buf)
+                FfiConverterString.write(value.`msg`, buf)
+                Unit
+            }
+        }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
+    }
+
+}
+
+
+
+
+
+sealed class Web5RustCoreException: Exception() {
+    
+    class Exception(
+        
+        val `type`: kotlin.String, 
+        
+        val `variant`: kotlin.String, 
+        
+        val `msg`: kotlin.String
+        ) : Web5RustCoreException() {
+        override val message
+            get() = "type=${ `type` }, variant=${ `variant` }, msg=${ `msg` }"
+    }
+    
+
+    companion object ErrorHandler : UniffiRustCallStatusErrorHandler<Web5RustCoreException> {
+        override fun lift(error_buf: RustBuffer.ByValue): Web5RustCoreException = FfiConverterTypeWeb5RustCoreError.lift(error_buf)
+    }
+
+    
+}
+
+public object FfiConverterTypeWeb5RustCoreError : FfiConverterRustBuffer<Web5RustCoreException> {
+    override fun read(buf: ByteBuffer): Web5RustCoreException {
+        
+
+        return when(buf.getInt()) {
+            1 -> Web5RustCoreException.Exception(
+                FfiConverterString.read(buf),
+                FfiConverterString.read(buf),
+                FfiConverterString.read(buf),
+                )
+            else -> throw RuntimeException("invalid error enum value, something is very wrong!!")
+        }
+    }
+
+    override fun allocationSize(value: Web5RustCoreException): ULong {
+        return when(value) {
+            is Web5RustCoreException.Exception -> (
+                // Add the size for the Int that specifies the variant plus the size needed for all fields
+                4UL
+                + FfiConverterString.allocationSize(value.`type`)
+                + FfiConverterString.allocationSize(value.`variant`)
+                + FfiConverterString.allocationSize(value.`msg`)
+            )
+        }
+    }
+
+    override fun write(value: Web5RustCoreException, buf: ByteBuffer) {
+        when(value) {
+            is Web5RustCoreException.Exception -> {
+                buf.putInt(1)
+                FfiConverterString.write(value.`type`, buf)
+                FfiConverterString.write(value.`variant`, buf)
+                FfiConverterString.write(value.`msg`, buf)
+                Unit
+            }
+        }.let { /* this makes the `when` an expression, which ensures it is exhaustive */ }
+    }
+
+}
+
+
+
+
 public object FfiConverterOptionalBoolean: FfiConverterRustBuffer<kotlin.Boolean?> {
     override fun read(buf: ByteBuffer): kotlin.Boolean? {
         if (buf.get().toInt() == 0) {
@@ -6590,31 +6210,6 @@ public object FfiConverterOptionalMapStringString: FfiConverterRustBuffer<Map<ko
         } else {
             buf.put(1)
             FfiConverterMapStringString.write(value, buf)
-        }
-    }
-}
-
-
-
-
-public object FfiConverterSequenceUByte: FfiConverterRustBuffer<List<kotlin.UByte>> {
-    override fun read(buf: ByteBuffer): List<kotlin.UByte> {
-        val len = buf.getInt()
-        return List<kotlin.UByte>(len) {
-            FfiConverterUByte.read(buf)
-        }
-    }
-
-    override fun allocationSize(value: List<kotlin.UByte>): ULong {
-        val sizeForLength = 4UL
-        val sizeForItems = value.map { FfiConverterUByte.allocationSize(it) }.sum()
-        return sizeForLength + sizeForItems
-    }
-
-    override fun write(value: List<kotlin.UByte>, buf: ByteBuffer) {
-        buf.putInt(value.size)
-        value.iterator().forEach {
-            FfiConverterUByte.write(it, buf)
         }
     }
 }

--- a/bound/kt/src/main/kotlin/tbdex/sdk/web5/Signer.kt
+++ b/bound/kt/src/main/kotlin/tbdex/sdk/web5/Signer.kt
@@ -13,8 +13,7 @@ class OuterSigner : Signer {
         this.rustCoreSigner = rustCoreSigner
     }
 
-    @OptIn(ExperimentalUnsignedTypes::class)
     override fun sign(payload: ByteArray): ByteArray {
-        return this.rustCoreSigner.sign(payload.toUByteArray().toList())
+        return this.rustCoreSigner.sign(payload)
     }
 }

--- a/bound/kt/src/test/kotlin/tbdex/sdk/httpclient/E2ePfiExemplarIntegrationTest.kt
+++ b/bound/kt/src/test/kotlin/tbdex/sdk/httpclient/E2ePfiExemplarIntegrationTest.kt
@@ -16,7 +16,7 @@ class E2ePfiExemplarIntegrationTest {
 
         val didUri = "did:dht:1fs5hnxsgtxgdr4wzqi38cnj46b1whhn94ojwo66g8hsc5bt3fgy"
         val keyManager = InMemoryKeyManager(listOf())
-        val publicJwk = keyManager.importPrivateJwk(Jwk(
+        keyManager.importPrivateJwk(Jwk(
             "EdDSA",
             "OKP",
             "Ed25519",

--- a/bound/kt/src/test/kotlin/tbdex/sdk/httpclient/E2ePfiExemplarIntegrationTest.kt
+++ b/bound/kt/src/test/kotlin/tbdex/sdk/httpclient/E2ePfiExemplarIntegrationTest.kt
@@ -12,89 +12,83 @@ import tbdex.sdk.web5.*
 class E2ePfiExemplarIntegrationTest {
     @Test
     fun `can make the happy path`() {
-        try {
-            val pfiDidUri = "did:dht:swit41ctrddy1s38c5j46yfgbxmwo1emau71zo5hn1tws1g63hiy"
+        val pfiDidUri = "did:dht:swit41ctrddy1s38c5j46yfgbxmwo1emau71zo5hn1tws1g63hiy"
 
-            val didUri = "did:dht:1fs5hnxsgtxgdr4wzqi38cnj46b1whhn94ojwo66g8hsc5bt3fgy"
-            val keyManager = InMemoryKeyManager(listOf())
-            val publicJwk = keyManager.importPrivateJwk(Jwk(
-                "EdDSA",
-                "OKP",
-                "Ed25519",
-                "jVOdpSIN-DhddW_XVnDipukuzu6-8zieXQtkECZYJ04",
-                "kW2-CfY0XmGTVLurk7BJ14Mqc4L-oJpD3jH5ZmwxyUw",
-                null
-            ))
-            val bearerDid = BearerDid(didUri, keyManager)
+        val didUri = "did:dht:1fs5hnxsgtxgdr4wzqi38cnj46b1whhn94ojwo66g8hsc5bt3fgy"
+        val keyManager = InMemoryKeyManager(listOf())
+        val publicJwk = keyManager.importPrivateJwk(Jwk(
+            "EdDSA",
+            "OKP",
+            "Ed25519",
+            "jVOdpSIN-DhddW_XVnDipukuzu6-8zieXQtkECZYJ04",
+            "kW2-CfY0XmGTVLurk7BJ14Mqc4L-oJpD3jH5ZmwxyUw",
+            null
+        ))
+        val bearerDid = BearerDid(didUri, keyManager)
 
-            // get offerings
-            val offerings = getOfferings(pfiDidUri)
-            println("Successfully retrieved offerings")
-            assertNotEquals(0, offerings.size)
+        // get offerings
+        val offerings = getOfferings(pfiDidUri)
+        println("Successfully retrieved offerings")
+        assertNotEquals(0, offerings.size)
 
-            // get balance
-            // TODO pfi-exemplar currently returning invalid balances (missing signature)
+        // get balance
+        // TODO pfi-exemplar currently returning invalid balances (missing signature)
 //            val balances = getBalances(pfiDidUri, bearerDid)
 //            println("Successfully retrieved balances")
 //            assertNotEquals(0, balances.size)
 
-            // create exchange
-            val rfq = Rfq(
-                bearerDid,
-                pfiDidUri,
-                bearerDid.did.uri,
-                CreateRfqData(
-                    offeringId = offerings[0].metadata.id,
-                    payin = CreateSelectedPayinMethod(
-                        "USD_LEDGER",
-                        null,
-                        "101"
-                    ),
-                    payout = CreateSelectedPayoutMethod(
-                        "MOMO_MPESA",
-                        ObjectMapper().readTree("""{
-                            "phoneNumber": "867-5309",
-                            "reason": "cause"
-                        }""")
-                    ),
-                    claims = listOf("eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6YzhkOWh1azduaG9tNG43emdybWE2cGp5Y3k2NzR1cmFhNHBvcDl1dXQ0MWdiOXd5OHNueSMwIn0.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiU2FuY3Rpb25DcmVkZW50aWFsIl0sImlkIjoidXJuOnV1aWQ6ZjBkYWNlZmItNDVlNy00YWEyLTkxNDctMTZmYTBiYzc3ZTVjIiwiaXNzdWVyIjoiZGlkOmRodDpjOGQ5aHVrN25ob200bjd6Z3JtYTZwanljeTY3NHVyYWE0cG9wOXV1dDQxZ2I5d3k4c255IiwiaXNzdWFuY2VEYXRlIjoiMjAyNC0wNi0yNFQxNDoxNTozNVoiLCJjcmVkZW50aWFsU3ViamVjdCI6eyJpZCI6ImRpZDpkaHQ6MWZzNWhueHNndHhnZHI0d3pxaTM4Y25qNDZiMXdoaG45NG9qd282Nmc4aHNjNWJ0M2ZneSIsImJlZXAiOiJib29wIn19LCJuYmYiOjE3MTkyMzg1MzUsImp0aSI6InVybjp1dWlkOmYwZGFjZWZiLTQ1ZTctNGFhMi05MTQ3LTE2ZmEwYmM3N2U1YyIsImlzcyI6ImRpZDpkaHQ6YzhkOWh1azduaG9tNG43emdybWE2cGp5Y3k2NzR1cmFhNHBvcDl1dXQ0MWdiOXd5OHNueSIsInN1YiI6ImRpZDpkaHQ6MWZzNWhueHNndHhnZHI0d3pxaTM4Y25qNDZiMXdoaG45NG9qd282Nmc4aHNjNWJ0M2ZneSIsImlhdCI6MTcxOTIzODUzNX0.DvDFIl8BTuHRk7VkB82OhYpX0WzBb3BucvAqfXiS92QCiRokXCgQAsOwbbSODoDaFWbHG0BJmWM-eDPcCoucCw")
+        // create exchange
+        val rfq = Rfq(
+            bearerDid,
+            pfiDidUri,
+            bearerDid.did.uri,
+            CreateRfqData(
+                offeringId = offerings[0].metadata.id,
+                payin = CreateSelectedPayinMethod(
+                    "USD_LEDGER",
+                    null,
+                    "101"
                 ),
-                "1.0", null
-            )
-            createExchange(rfq, null)
-            println("Successfully created exchange")
+                payout = CreateSelectedPayoutMethod(
+                    "MOMO_MPESA",
+                    ObjectMapper().readTree("""{
+                        "phoneNumber": "867-5309",
+                        "reason": "cause"
+                    }""")
+                ),
+                claims = listOf("eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpkaHQ6YzhkOWh1azduaG9tNG43emdybWE2cGp5Y3k2NzR1cmFhNHBvcDl1dXQ0MWdiOXd5OHNueSMwIn0.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiU2FuY3Rpb25DcmVkZW50aWFsIl0sImlkIjoidXJuOnV1aWQ6ZjBkYWNlZmItNDVlNy00YWEyLTkxNDctMTZmYTBiYzc3ZTVjIiwiaXNzdWVyIjoiZGlkOmRodDpjOGQ5aHVrN25ob200bjd6Z3JtYTZwanljeTY3NHVyYWE0cG9wOXV1dDQxZ2I5d3k4c255IiwiaXNzdWFuY2VEYXRlIjoiMjAyNC0wNi0yNFQxNDoxNTozNVoiLCJjcmVkZW50aWFsU3ViamVjdCI6eyJpZCI6ImRpZDpkaHQ6MWZzNWhueHNndHhnZHI0d3pxaTM4Y25qNDZiMXdoaG45NG9qd282Nmc4aHNjNWJ0M2ZneSIsImJlZXAiOiJib29wIn19LCJuYmYiOjE3MTkyMzg1MzUsImp0aSI6InVybjp1dWlkOmYwZGFjZWZiLTQ1ZTctNGFhMi05MTQ3LTE2ZmEwYmM3N2U1YyIsImlzcyI6ImRpZDpkaHQ6YzhkOWh1azduaG9tNG43emdybWE2cGp5Y3k2NzR1cmFhNHBvcDl1dXQ0MWdiOXd5OHNueSIsInN1YiI6ImRpZDpkaHQ6MWZzNWhueHNndHhnZHI0d3pxaTM4Y25qNDZiMXdoaG45NG9qd282Nmc4aHNjNWJ0M2ZneSIsImlhdCI6MTcxOTIzODUzNX0.DvDFIl8BTuHRk7VkB82OhYpX0WzBb3BucvAqfXiS92QCiRokXCgQAsOwbbSODoDaFWbHG0BJmWM-eDPcCoucCw")
+            ),
+            "1.0", null
+        )
+        createExchange(rfq, null)
+        println("Successfully created exchange")
 
-            // get quote
-            var exchange = getExchange(pfiDidUri, bearerDid, rfq.metadata.exchangeId)
-            val quote = exchange.quote ?: throw Exception("Quote should not be null")
-            println("Successfully retrieved quote")
+        // get quote
+        var exchange = getExchange(pfiDidUri, bearerDid, rfq.metadata.exchangeId)
+        val quote = exchange.quote ?: throw Exception("Quote should not be null")
+        println("Successfully retrieved quote")
 
-            // submit order
-            submitOrder(Order(
-                bearerDid,
-                pfiDidUri,
-                bearerDid.did.uri,
-                quote.metadata.exchangeId,
-                "1.0", null
-            ))
-            println("Successfully submitted order")
+        // submit order
+        submitOrder(Order(
+            bearerDid,
+            pfiDidUri,
+            bearerDid.did.uri,
+            quote.metadata.exchangeId,
+            "1.0", null
+        ))
+        println("Successfully submitted order")
 
-            // get order status and close
-            var count = 0
-            while (exchange.close == null) {
-                Thread.sleep(5000)
-                exchange = getExchange(pfiDidUri, bearerDid, quote.metadata.exchangeId)
-                count += 1
-                if (count >= 3) {
-                    throw Exception("Tried 3 times to fetch order status and close and failed")
-                }
+        // get order status and close
+        var count = 0
+        while (exchange.close == null) {
+            Thread.sleep(5000)
+            exchange = getExchange(pfiDidUri, bearerDid, quote.metadata.exchangeId)
+            count += 1
+            if (count >= 3) {
+                throw Exception("Tried 3 times to fetch order status and close and failed")
             }
-
-            println("Exchange completed successfully!")
-        } catch (ex: RustCoreException) {
-            fail("RustCoreException caught || ${ex.errorType()} || ${ex.variant()} || ${ex.message()}")
-        } catch (ex: Web5RustCoreException) {
-            fail("Web5RustCoreException caught || ${ex.errorType()} || ${ex.variant()} || ${ex.message()}")
         }
+
+        println("Exchange completed successfully!")
     }
 }


### PR DESCRIPTION
I discovered this while working on https://github.com/TBD54566975/web5-rs/pull/255/, that we can improve the `RustCoreError` console logging

Previously, given a `RustCoreException` (UniFFI renames it to be `*Exception` rather than `*Error`) was thrown, we would just see this:

```
tbdex.sdk.rust.RustCoreException
```

But now, with the improvements in this PR, we see this:

```
tbdex.sdk.rust.RustCoreException$Exception: type=tbdex::resources::ResourceError, variant=SerdeJson, msg=serde json error key must be a string at line 1 column 2
```