### PR TITLE
update last test vectors

### DIFF
--- a/bound/kt/src/test/kotlin/tbdex/sdk/vectors/TbdexTestVectorsProtocolTest.kt
+++ b/bound/kt/src/test/kotlin/tbdex/sdk/vectors/TbdexTestVectorsProtocolTest.kt
@@ -47,6 +47,16 @@ class TbdexTestVectorsProtocolTest {
         testVector("parse-quote.json", ::Quote) { it.toJson() }
     }
 
+    @Test
+    fun parse_close() {
+        testVector("parse-close.json", ::Close) { it.toJson() }
+    }
+
+    @Test
+    fun parse_cancel() {
+        testVector("parse-cancel.json", ::Cancel) { it.toJson() }
+    }
+
     private fun <T> testVector(vectorFileName: String, objectCreation: (String) -> T, toJson: (T) -> String) {
         val vector = TestVectors.getVector(vectorFileName)
         assertNotNull(vector)

--- a/bound/kt/src/test/kotlin/tbdex/sdk/vectors/TestVectors.kt
+++ b/bound/kt/src/test/kotlin/tbdex/sdk/vectors/TestVectors.kt
@@ -12,6 +12,7 @@ object TestVectors {
         val vectors = mutableMapOf<String, JsonNode>()
         val vectorFiles = arrayOf(
             "parse-close.json",
+            "parse-cancel.json",
             "parse-offering.json",
             "parse-order.json",
             "parse-orderstatus.json",
@@ -20,7 +21,7 @@ object TestVectors {
             "parse-rfq-omit-private-data.json",
             "parse-balance.json"
         )
-        
+
         val basePath = "../../tbdex/hosted/test-vectors/protocol/vectors/"
 
         for (vectorFile in vectorFiles) {

--- a/crates/tbdex/src/messages/quote.rs
+++ b/crates/tbdex/src/messages/quote.rs
@@ -106,26 +106,25 @@ pub struct PaymentInstruction {
     pub instruction: Option<String>,
 }
 
-// TODO: The test vector needs to be updated - https://github.com/TBD54566975/tbdex/blob/main/hosted/test-vectors/protocol/vectors/parse-quote.json
-// #[cfg(test)]
-// mod tbdex_test_vectors_protocol {
-//     use super::*;
-//     use std::fs;
-//
-//     #[derive(Debug, serde::Deserialize)]
-//     pub struct TestVector {
-//         pub input: String,
-//         pub output: Quote,
-//     }
-//
-//     #[test]
-//     fn parse_quote() {
-//         let path = "../../tbdex/hosted/test-vectors/protocol/vectors/parse-quote.json";
-//         let test_vector_json: String = fs::read_to_string(path).unwrap();
-//
-//         let test_vector: TestVector = serde_json::from_str(&test_vector_json).unwrap();
-//         let parsed_quote: Quote = Quote::from_json_string(&test_vector.input).unwrap();
-//
-//         assert_eq!(test_vector.output, parsed_quote);
-//     }
-// }
+#[cfg(test)]
+mod tbdex_test_vectors_protocol {
+    use super::*;
+    use std::fs;
+
+    #[derive(Debug, serde::Deserialize)]
+    pub struct TestVector {
+        pub input: String,
+        pub output: Quote,
+    }
+
+    #[test]
+    fn parse_quote() {
+        let path = "../../tbdex/hosted/test-vectors/protocol/vectors/parse-quote.json";
+        let test_vector_json: String = fs::read_to_string(path).unwrap();
+
+        let test_vector: TestVector = serde_json::from_str(&test_vector_json).unwrap();
+        let parsed_quote: Quote = Quote::from_json_string(&test_vector.input).unwrap();
+
+        assert_eq!(test_vector.output, parsed_quote);
+    }
+}


### PR DESCRIPTION
This change adds the last missing test vectors for full ✅  all the way down:

<img width="274" alt="image" src="https://github.com/user-attachments/assets/a41f683d-08a7-4f06-83d8-d31d1b623dd5">

After this change goes through we should have full checks all the way down
