### PR TITLE
Add pagination to get_exchange_ids() function

### DIFF
--- a/bindings/tbdex_uniffi/src/http_client/exchanges.rs
+++ b/bindings/tbdex_uniffi/src/http_client/exchanges.rs
@@ -6,7 +6,7 @@ use crate::{
     },
 };
 use std::sync::{Arc, RwLock};
-use tbdex::http_client::exchanges::Exchange as InnerExchange;
+use tbdex::http_client::exchanges::{Exchange as InnerExchange, GetExchangeIdsQueryParams};
 use web5_uniffi_wrapper::dids::bearer_did::BearerDid;
 
 pub struct Exchange {
@@ -76,8 +76,15 @@ pub fn get_exchange(
     Ok(Exchange::from_inner(inner_exchange))
 }
 
-pub fn get_exchange_ids(pfi_did_uri: String, bearer_did: Arc<BearerDid>) -> Result<Vec<String>> {
-    let exchange_ids =
-        tbdex::http_client::exchanges::get_exchange_ids(&pfi_did_uri, &bearer_did.0.clone())?;
+pub fn get_exchange_ids(
+    pfi_did_uri: String,
+    bearer_did: Arc<BearerDid>,
+    query_params: Option<GetExchangeIdsQueryParams>,
+) -> Result<Vec<String>> {
+    let exchange_ids = tbdex::http_client::exchanges::get_exchange_ids(
+        &pfi_did_uri,
+        &bearer_did.0.clone(),
+        query_params,
+    )?;
     Ok(exchange_ids)
 }

--- a/bindings/tbdex_uniffi/src/lib.rs
+++ b/bindings/tbdex_uniffi/src/lib.rs
@@ -42,6 +42,7 @@ use crate::{
 };
 use tbdex::{
     http::{ErrorDetail as ErrorDetailData, ErrorResponseBody as ErrorResponseBodyData},
+    http_client::exchanges::GetExchangeIdsQueryParams as GetExchangeIdsQueryParamsData,
     messages::{
         cancel::{Cancel as CancelData, CancelData as CancelDataData},
         close::{Close as CloseData, CloseData as CloseDataData},

--- a/bindings/tbdex_uniffi/src/tbdex.udl
+++ b/bindings/tbdex_uniffi/src/tbdex.udl
@@ -12,7 +12,7 @@ namespace tbdex {
   [Throws=TbdexSdkError]
   ExchangeData get_exchange(string pfi_did_uri, BearerDid bearer_did, string exchange_id);
   [Throws=TbdexSdkError]
-  sequence<string> get_exchange_ids(string pfi_did_uri, BearerDid bearer_did);
+  sequence<string> get_exchange_ids(string pfi_did_uri, BearerDid bearer_did, GetExchangeIdsQueryParamsData? query_params);
 };
 
 [Error]
@@ -447,7 +447,10 @@ interface ReplyToRequestBody {
   ReplyToRequestBodyData get_data();
 };
 
-
+dictionary GetExchangeIdsQueryParamsData {
+  i64? pagination_offset;
+  i64? pagination_limit;
+};
 
 
 

--- a/bound/kt/src/main/kotlin/tbdex/sdk/httpclient/Exchanges.kt
+++ b/bound/kt/src/main/kotlin/tbdex/sdk/httpclient/Exchanges.kt
@@ -1,6 +1,7 @@
 package tbdex.sdk.httpclient
 
 import tbdex.sdk.messages.*
+import tbdex.sdk.rust.GetExchangeIdsQueryParamsData as RustCoreGetExchangeIdsQueryParams
 import tbdex.sdk.rust.SystemArchitecture
 import tbdex.sdk.rust.ExchangeData as RustCoreExchange
 import tbdex.sdk.rust.createExchange as rustCoreCreateExchange
@@ -63,10 +64,12 @@ fun getExchange(pfiDidUri: String, bearerDid: BearerDid, exchangeId: String): Ex
     return Exchange.fromRustCore(rustCoreExchange)
 }
 
-fun getExchangeIds(pfiDidUri: String, bearerDid: BearerDid): List<String> {
+typealias GetExchangeIdsQueryParams = RustCoreGetExchangeIdsQueryParams
+
+fun getExchangeIds(pfiDidUri: String, bearerDid: BearerDid, queryParams: GetExchangeIdsQueryParams? = null): List<String> {
     SystemArchitecture.set() // ensure the sys arch is set for first-time loading
 
-    return rustCoreGetExchangeIds(pfiDidUri, bearerDid.rustCoreBearerDid)
+    return rustCoreGetExchangeIds(pfiDidUri, bearerDid.rustCoreBearerDid, queryParams)
 }
 
 

--- a/bound/kt/src/main/kotlin/tbdex/sdk/rust/UniFFI.kt
+++ b/bound/kt/src/main/kotlin/tbdex/sdk/rust/UniFFI.kt
@@ -1330,7 +1330,7 @@ internal interface UniffiLib : Library {
     ): RustBuffer.ByValue
     fun uniffi_tbdex_uniffi_fn_func_get_exchange(`pfiDidUri`: RustBuffer.ByValue,`bearerDid`: Pointer,`exchangeId`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
-    fun uniffi_tbdex_uniffi_fn_func_get_exchange_ids(`pfiDidUri`: RustBuffer.ByValue,`bearerDid`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
+    fun uniffi_tbdex_uniffi_fn_func_get_exchange_ids(`pfiDidUri`: RustBuffer.ByValue,`bearerDid`: Pointer,`queryParams`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
     fun uniffi_tbdex_uniffi_fn_func_get_offerings(`pfiDidUri`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
@@ -1698,7 +1698,7 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
     if (lib.uniffi_tbdex_uniffi_checksum_func_get_exchange() != 35978.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_tbdex_uniffi_checksum_func_get_exchange_ids() != 44594.toShort()) {
+    if (lib.uniffi_tbdex_uniffi_checksum_func_get_exchange_ids() != 1186.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_tbdex_uniffi_checksum_func_get_offerings() != 28498.toShort()) {
@@ -2061,6 +2061,26 @@ inline fun <T : Disposable?, R> T.use(block: (T) -> R) =
 
 /** Used to instantiate an interface without an actual pointer, for fakes in tests, mostly. */
 object NoPointer
+
+public object FfiConverterLong: FfiConverter<Long, Long> {
+    override fun lift(value: Long): Long {
+        return value
+    }
+
+    override fun read(buf: ByteBuffer): Long {
+        return buf.getLong()
+    }
+
+    override fun lower(value: Long): Long {
+        return value
+    }
+
+    override fun allocationSize(value: Long) = 8UL
+
+    override fun write(value: Long, buf: ByteBuffer) {
+        buf.putLong(value)
+    }
+}
 
 public object FfiConverterBoolean: FfiConverter<Boolean, Byte> {
     override fun lift(value: Byte): Boolean {
@@ -9212,6 +9232,35 @@ public object FfiConverterTypeGetBalancesResponseBodyData: FfiConverterRustBuffe
 
 
 
+data class GetExchangeIdsQueryParamsData (
+    var `paginationOffset`: kotlin.Long?, 
+    var `paginationLimit`: kotlin.Long?
+) {
+    
+    companion object
+}
+
+public object FfiConverterTypeGetExchangeIdsQueryParamsData: FfiConverterRustBuffer<GetExchangeIdsQueryParamsData> {
+    override fun read(buf: ByteBuffer): GetExchangeIdsQueryParamsData {
+        return GetExchangeIdsQueryParamsData(
+            FfiConverterOptionalLong.read(buf),
+            FfiConverterOptionalLong.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: GetExchangeIdsQueryParamsData) = (
+            FfiConverterOptionalLong.allocationSize(value.`paginationOffset`) +
+            FfiConverterOptionalLong.allocationSize(value.`paginationLimit`)
+    )
+
+    override fun write(value: GetExchangeIdsQueryParamsData, buf: ByteBuffer) {
+            FfiConverterOptionalLong.write(value.`paginationOffset`, buf)
+            FfiConverterOptionalLong.write(value.`paginationLimit`, buf)
+    }
+}
+
+
+
 data class GetExchangeResponseBodyData (
     var `data`: List<GetExchangeResponseBodyDataSerializedMessage>
 ) {
@@ -10245,6 +10294,35 @@ public object FfiConverterTypeWeb5RustCoreError : FfiConverterRustBuffer<Web5Rus
 
 
 
+public object FfiConverterOptionalLong: FfiConverterRustBuffer<kotlin.Long?> {
+    override fun read(buf: ByteBuffer): kotlin.Long? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterLong.read(buf)
+    }
+
+    override fun allocationSize(value: kotlin.Long?): ULong {
+        if (value == null) {
+            return 1UL
+        } else {
+            return 1UL + FfiConverterLong.allocationSize(value)
+        }
+    }
+
+    override fun write(value: kotlin.Long?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterLong.write(value, buf)
+        }
+    }
+}
+
+
+
+
 public object FfiConverterOptionalBoolean: FfiConverterRustBuffer<kotlin.Boolean?> {
     override fun read(buf: ByteBuffer): kotlin.Boolean? {
         if (buf.get().toInt() == 0) {
@@ -10441,6 +10519,35 @@ public object FfiConverterOptionalTypeQuote: FfiConverterRustBuffer<Quote?> {
         } else {
             buf.put(1)
             FfiConverterTypeQuote.write(value, buf)
+        }
+    }
+}
+
+
+
+
+public object FfiConverterOptionalTypeGetExchangeIdsQueryParamsData: FfiConverterRustBuffer<GetExchangeIdsQueryParamsData?> {
+    override fun read(buf: ByteBuffer): GetExchangeIdsQueryParamsData? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterTypeGetExchangeIdsQueryParamsData.read(buf)
+    }
+
+    override fun allocationSize(value: GetExchangeIdsQueryParamsData?): ULong {
+        if (value == null) {
+            return 1UL
+        } else {
+            return 1UL + FfiConverterTypeGetExchangeIdsQueryParamsData.allocationSize(value)
+        }
+    }
+
+    override fun write(value: GetExchangeIdsQueryParamsData?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterTypeGetExchangeIdsQueryParamsData.write(value, buf)
         }
     }
 }
@@ -10878,11 +10985,11 @@ public object FfiConverterMapStringString: FfiConverterRustBuffer<Map<kotlin.Str
     }
     
 
-    @Throws(TbdexSdkException::class) fun `getExchangeIds`(`pfiDidUri`: kotlin.String, `bearerDid`: BearerDid): List<kotlin.String> {
+    @Throws(TbdexSdkException::class) fun `getExchangeIds`(`pfiDidUri`: kotlin.String, `bearerDid`: BearerDid, `queryParams`: GetExchangeIdsQueryParamsData?): List<kotlin.String> {
             return FfiConverterSequenceString.lift(
     uniffiRustCallWithError(TbdexSdkException) { _status ->
     UniffiLib.INSTANCE.uniffi_tbdex_uniffi_fn_func_get_exchange_ids(
-        FfiConverterString.lower(`pfiDidUri`),FfiConverterTypeBearerDid.lower(`bearerDid`),_status)
+        FfiConverterString.lower(`pfiDidUri`),FfiConverterTypeBearerDid.lower(`bearerDid`),FfiConverterOptionalTypeGetExchangeIdsQueryParamsData.lower(`queryParams`),_status)
 }
     )
     }

--- a/crates/tbdex/src/http_client/exchanges.rs
+++ b/crates/tbdex/src/http_client/exchanges.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use super::{get_service_endpoint, send_request, Result};
+use super::{add_pagination, get_service_endpoint, send_request, Result};
 use crate::http::exchanges::GetExchangesResponseBody;
 use crate::{
     http::exchanges::{
@@ -151,9 +151,29 @@ pub fn get_exchange(
     Ok(exchange)
 }
 
-pub fn get_exchange_ids(pfi_did: &str, requestor_did: &BearerDid) -> Result<Vec<String>> {
+#[derive(Clone, Default, Debug, PartialEq)]
+pub struct GetExchangeIdsQueryParams {
+    pub pagination_offset: Option<i64>,
+    pub pagination_limit: Option<i64>,
+}
+
+pub fn get_exchange_ids(
+    pfi_did: &str,
+    requestor_did: &BearerDid,
+    query_params: Option<GetExchangeIdsQueryParams>,
+) -> Result<Vec<String>> {
     let service_endpoint = get_service_endpoint(pfi_did)?;
     let get_exchanges_endpoint = format!("{}/exchanges", service_endpoint);
+
+    let get_exchanges_endpoint = if let Some(params) = query_params {
+        add_pagination(
+            &get_exchanges_endpoint,
+            params.pagination_offset,
+            params.pagination_limit,
+        )
+    } else {
+        get_exchanges_endpoint
+    };
 
     let access_token = generate_access_token(pfi_did, requestor_did)?;
 

--- a/crates/tbdex/src/http_client/mod.rs
+++ b/crates/tbdex/src/http_client/mod.rs
@@ -122,6 +122,28 @@ pub(crate) fn get_service_endpoint(pfi_did_uri: &str) -> Result<String> {
     Ok(endpoint)
 }
 
+fn add_pagination(
+    endpoint: &str,
+    pagination_offset: Option<i64>,
+    pagination_limit: Option<i64>,
+) -> String {
+    let mut query_string = String::new();
+
+    if let Some(offset) = pagination_offset {
+        query_string.push_str(&format!("?page[offset]={}", offset));
+    }
+
+    if let Some(limit) = pagination_limit {
+        if query_string.is_empty() {
+            query_string.push_str(&format!("?page[limit]={}", limit));
+        } else {
+            query_string.push_str(&format!("&page[limit]={}", limit));
+        }
+    }
+
+    format!("{}{}", endpoint, query_string)
+}
+
 fn send_request<T: Serialize, U: DeserializeOwned>(
     url: &str,
     method: Method,

--- a/docs/API_DESIGN.md
+++ b/docs/API_DESIGN.md
@@ -64,6 +64,7 @@
   - [`get_exchange()`](#get_exchange)
   - [`Exchange`](#exchange)
   - [`get_exchange_ids()`](#get_exchange_ids)
+    - [`GetExchangeIdsQueryParams`](#getexchangeidsqueryparams)
 
 > [!WARNING]
 >
@@ -628,5 +629,16 @@ CLASS Exchange
 ## `get_exchange_ids()`
 
 ```pseudocode!
-FUNCTION get_exchange_ids(pfi_did_uri: string, bearer_did: BearerDid): []string
+FUNCTION get_exchange_ids(
+  pfi_did_uri: string, 
+  bearer_did: BearerDid, 
+  query_params: GetExchangeIdsQueryParams?): []string
+```
+
+### `GetExchangeIdsQueryParams`
+
+```pseudocode!
+CLASS GetExchangeIdsQueryParams
+  PUBLIC DATA pagination_offset: int
+  PUBLIC DATA pagination_limit: int
 ```

--- a/examples/hosted-wallet-kt/pfi/build.gradle.kts
+++ b/examples/hosted-wallet-kt/pfi/build.gradle.kts
@@ -8,13 +8,6 @@ repositories {
     mavenLocal()
 
     maven {
-        name = "tbd-oss-thirdparty"
-        url = uri("https://blockxyz.jfrog.io/artifactory/tbd-oss-thirdparty-maven2/")
-        mavenContent {
-            releasesOnly()
-        }
-    }
-    maven {
         name = "tbd-oss-snapshots"
         url = uri("https://blockxyz.jfrog.io/artifactory/tbd-oss-snapshots-maven2/")
         mavenContent {
@@ -28,7 +21,16 @@ dependencies {
     implementation("com.sparkjava:spark-core:2.9.4")
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
 
-    implementation("xyz.block:tbdex:commit-d6edc85-SNAPSHOT")
+    // For local development dependency.
+    // Install the dependency locally by running `mvn install` in the `bound/kt` directory
+    // implementation("xyz.block:tbdex:0.0.0-main-SNAPSHOT")
+
+    // For a snapshot from maven
+    // Update the short git commit SHA below
+    // implementation("xyz.block:tbdex:commit-d6edc85-SNAPSHOT")
+
+    // For the official release on maven central
+    implementation("xyz.block:tbdex:3.0.0")
 }
 
 java {

--- a/examples/hosted-wallet-kt/pfi/build.gradle.kts
+++ b/examples/hosted-wallet-kt/pfi/build.gradle.kts
@@ -27,10 +27,10 @@ dependencies {
 
     // For a snapshot from maven
     // Update the short git commit SHA below
-    // implementation("xyz.block:tbdex:commit-d6edc85-SNAPSHOT")
+    implementation("xyz.block:tbdex:commit-cc93a9c-SNAPSHOT")
 
     // For the official release on maven central
-    implementation("xyz.block:tbdex:3.0.0")
+    // implementation("xyz.block:tbdex:3.0.0")
 }
 
 java {

--- a/examples/hosted-wallet-kt/pfi/src/main/kotlin/api/Exchanges.kt
+++ b/examples/hosted-wallet-kt/pfi/src/main/kotlin/api/Exchanges.kt
@@ -15,7 +15,7 @@ import web5.sdk.dids.BearerDid
 
 class Exchanges(private val bearerDid: BearerDid, private val offeringsRepository: data.Offerings) {
     init {
-        get("/exchanges") { _, res -> getExchanges(res) }
+        get("/exchanges") { req, res -> getExchangeIds(req, res) }
         get("/exchanges/:id") { req, res -> getExchange(req,res) }
 
         post("/exchanges") { req, res -> createExchange(req, res) }
@@ -44,10 +44,14 @@ class Exchanges(private val bearerDid: BearerDid, private val offeringsRepositor
         return responseBody.toJsonString()
     }
 
-    private fun getExchanges(res: Response): String {
+    private fun getExchangeIds(req: Request, res: Response): String {
         println("GET /exchanges")
 
-        val responseBody = GetExchangesResponseBody(exchangeIdToExchange.keys.toList())
+        val offset = req.queryParams("page[offset]")?.toIntOrNull() ?: 0
+        val limit = req.queryParams("page[limit]")?.toIntOrNull() ?: 10
+        val paginatedExchanges = exchangeIdToExchange.keys.toList().drop(offset).take(limit)
+
+        val responseBody = GetExchangesResponseBody(paginatedExchanges)
 
         res.type("application/json")
         return responseBody.toJsonString()

--- a/examples/hosted-wallet-kt/wallet/build.gradle.kts
+++ b/examples/hosted-wallet-kt/wallet/build.gradle.kts
@@ -22,14 +22,14 @@ dependencies {
 
     // For local development dependency.
     // Install the dependency locally by running `mvn install` in the `bound/kt` directory
-     implementation("xyz.block:tbdex:0.0.0-main-SNAPSHOT")
+    // implementation("xyz.block:tbdex:0.0.0-main-SNAPSHOT")
 
     // For a snapshot from maven
     // Update the short git commit SHA below
-    // implementation("xyz.block:tbdex:commit-d6edc85-SNAPSHOT")
+    implementation("xyz.block:tbdex:commit-cc93a9c-SNAPSHOT")
 
     // For the official release on maven central
-//    implementation("xyz.block:tbdex:3.0.0")
+    // implementation("xyz.block:tbdex:3.0.0")
 }
 
 java {

--- a/examples/hosted-wallet-kt/wallet/build.gradle.kts
+++ b/examples/hosted-wallet-kt/wallet/build.gradle.kts
@@ -8,13 +8,6 @@ repositories {
     mavenLocal()
 
     maven {
-        name = "tbd-oss-thirdparty"
-        url = uri("https://blockxyz.jfrog.io/artifactory/tbd-oss-thirdparty-maven2/")
-        mavenContent {
-            releasesOnly()
-        }
-    }
-    maven {
         name = "tbd-oss-snapshots"
         url = uri("https://blockxyz.jfrog.io/artifactory/tbd-oss-snapshots-maven2/")
         mavenContent {
@@ -27,7 +20,16 @@ dependencies {
     implementation(kotlin("stdlib"))
     implementation("com.sparkjava:spark-core:2.9.4")
 
-    implementation("xyz.block:tbdex:commit-d6edc85-SNAPSHOT")
+    // For local development dependency.
+    // Install the dependency locally by running `mvn install` in the `bound/kt` directory
+     implementation("xyz.block:tbdex:0.0.0-main-SNAPSHOT")
+
+    // For a snapshot from maven
+    // Update the short git commit SHA below
+    // implementation("xyz.block:tbdex:commit-d6edc85-SNAPSHOT")
+
+    // For the official release on maven central
+//    implementation("xyz.block:tbdex:3.0.0")
 }
 
 java {

--- a/examples/hosted-wallet-kt/wallet/src/main/kotlin/Main.kt
+++ b/examples/hosted-wallet-kt/wallet/src/main/kotlin/Main.kt
@@ -1,3 +1,4 @@
+import tbdex.sdk.httpclient.GetExchangeIdsQueryParams
 import java.io.File
 import java.util.Properties
 import web5.sdk.dids.BearerDid
@@ -45,6 +46,16 @@ fun main() {
 
             val allExchanges = tbdex.sdk.httpclient.getExchangeIds(pfiDidUri, bearerDid)
             println("All Exchanges Completed: $allExchanges")
+
+            val paginatedExchanges = tbdex.sdk.httpclient.getExchangeIds(
+                pfiDidUri,
+                bearerDid,
+                GetExchangeIdsQueryParams(
+                    paginationOffset = 1,
+                    paginationLimit = 2
+                )
+            )
+            println("Paginated Exchanges: $paginatedExchanges")
         }
     }
 }


### PR DESCRIPTION
This adds tbdex pagination for the `get_exchange_ids()` function from-APID-all-the-way-through-the-example app

Reference https://github.com/TBD54566975/tbdex/tree/main/specs/http-api#pagination